### PR TITLE
WIP:Feat/python stack

### DIFF
--- a/plugins/stack/python/black.ts
+++ b/plugins/stack/python/black.ts
@@ -1,50 +1,12 @@
 import { IntrospectFn } from "../deps.ts";
+import { hasDependency } from "./utils.ts";
 
 export interface Black {
   hasBlack: boolean;
 }
 
 export const introspect: IntrospectFn<Black | null> = async (context) => {
-  for await (const file of context.files.each("**/pyproject.toml")) {
-    const pyproject = await context.files.readToml(file.path);
-    const libs = {
-      ...(pyproject?.tool || {}),
-      ...(pyproject?.tool.poetry.dependencies || {}),
-      ...(pyproject?.tool.poetry["dev-dependencies"] || {}),
-    };
-    const hasBlack = Object.keys(libs).some((name) =>
-      name === "black"
-    );
-    if (hasBlack) {
-      return {
-        "hasBlack": true,
-      };
-    }
-  }
-  for await (const file of context.files.each("**/Pipfile")) {
-    const pipfile = await context.files.readToml(file.path);
-    const libs = {
-      ...(pipfile?.packages || {}),
-      ...(pipfile?.["dev-packages"] || {}),
-    };
-    const hasBlack = Object.keys(libs).some((name) =>
-      name === "black"
-    );
-    if (hasBlack) {
-      return {
-        "hasBlack": true,
-      };
-    }
-  }
-  for await (const file of context.files.each("**/requirements.txt")) {
-    const requirements = await Deno.readTextFile(file.path);
-    if (requirements.includes("black")) {
-      return {
-        "hasBlack": true,
-      };
-    }
-  }
   return {
-    "hasBlack": false,
+    hasBlack: await hasDependency("black", context),
   };
 };

--- a/plugins/stack/python/black.ts
+++ b/plugins/stack/python/black.ts
@@ -1,0 +1,50 @@
+import { IntrospectFn } from "../deps.ts";
+
+export interface Black {
+  hasBlack: boolean;
+}
+
+export const introspect: IntrospectFn<Black | null> = async (context) => {
+  for await (const file of context.files.each("**/pyproject.toml")) {
+    const pyproject = await context.files.readToml(file.path);
+    const libs = {
+      ...(pyproject?.tool || {}),
+      ...(pyproject?.tool.poetry.dependencies || {}),
+      ...(pyproject?.tool.poetry["dev-dependencies"] || {}),
+    };
+    const hasBlack = Object.keys(libs).some((name) =>
+      name === "black"
+    );
+    if (hasBlack) {
+      return {
+        "hasBlack": true,
+      };
+    }
+  }
+  for await (const file of context.files.each("**/Pipfile")) {
+    const pipfile = await context.files.readToml(file.path);
+    const libs = {
+      ...(pipfile?.packages || {}),
+      ...(pipfile?.["dev-packages"] || {}),
+    };
+    const hasBlack = Object.keys(libs).some((name) =>
+      name === "black"
+    );
+    if (hasBlack) {
+      return {
+        "hasBlack": true,
+      };
+    }
+  }
+  for await (const file of context.files.each("**/requirements.txt")) {
+    const requirements = await Deno.readTextFile(file.path);
+    if (requirements.includes("black")) {
+      return {
+        "hasBlack": true,
+      };
+    }
+  }
+  return {
+    "hasBlack": false,
+  };
+};

--- a/plugins/stack/python/flake8.ts
+++ b/plugins/stack/python/flake8.ts
@@ -1,50 +1,12 @@
 import { IntrospectFn } from "../deps.ts";
+import { hasDependency } from "./utils.ts";
 
 export interface Flake8 {
   hasFlake8: boolean;
 }
 
 export const introspect: IntrospectFn<Flake8 | null> = async (context) => {
-  for await (const file of context.files.each("**/pyproject.toml")) {
-    const pyproject = await context.files.readToml(file.path);
-    const libs = {
-      ...(pyproject?.tool || {}),
-      ...(pyproject?.tool.poetry.dependencies || {}),
-      ...(pyproject?.tool.poetry["dev-dependencies"] || {}),
-    };
-    const hasFlake8 = Object.keys(libs).some((name) =>
-      name === "flake8"
-    );
-    if (hasFlake8) {
-      return {
-        "hasFlake8": true,
-      };
-    }
-  }
-  for await (const file of context.files.each("**/Pipfile")) {
-    const pipfile = await context.files.readToml(file.path);
-    const libs = {
-      ...(pipfile?.packages || {}),
-      ...(pipfile?.["dev-packages"] || {}),
-    };
-    const hasFlake8 = Object.keys(libs).some((name) =>
-      name === "flake8"
-    );
-    if (hasFlake8) {
-      return {
-        "hasFlake8": true,
-      };
-    }
-  }
-  for await (const file of context.files.each("**/requirements.txt")) {
-    const requirements = await Deno.readTextFile(file.path);
-    if (requirements.includes("flake8")) {
-      return {
-        "hasFlake8": true,
-      };
-    }
-  }
   return {
-    "hasFlake8": false,
+    hasFlake8: await hasDependency("flake8", context),
   };
 };

--- a/plugins/stack/python/flake8.ts
+++ b/plugins/stack/python/flake8.ts
@@ -1,0 +1,50 @@
+import { IntrospectFn } from "../deps.ts";
+
+export interface Flake8 {
+  hasFlake8: boolean;
+}
+
+export const introspect: IntrospectFn<Flake8 | null> = async (context) => {
+  for await (const file of context.files.each("**/pyproject.toml")) {
+    const pyproject = await context.files.readToml(file.path);
+    const libs = {
+      ...(pyproject?.tool || {}),
+      ...(pyproject?.tool.poetry.dependencies || {}),
+      ...(pyproject?.tool.poetry["dev-dependencies"] || {}),
+    };
+    const hasFlake8 = Object.keys(libs).some((name) =>
+      name === "flake8"
+    );
+    if (hasFlake8) {
+      return {
+        "hasFlake8": true,
+      };
+    }
+  }
+  for await (const file of context.files.each("**/Pipfile")) {
+    const pipfile = await context.files.readToml(file.path);
+    const libs = {
+      ...(pipfile?.packages || {}),
+      ...(pipfile?.["dev-packages"] || {}),
+    };
+    const hasFlake8 = Object.keys(libs).some((name) =>
+      name === "flake8"
+    );
+    if (hasFlake8) {
+      return {
+        "hasFlake8": true,
+      };
+    }
+  }
+  for await (const file of context.files.each("**/requirements.txt")) {
+    const requirements = await Deno.readTextFile(file.path);
+    if (requirements.includes("flake8")) {
+      return {
+        "hasFlake8": true,
+      };
+    }
+  }
+  return {
+    "hasFlake8": false,
+  };
+};

--- a/plugins/stack/python/formatters.ts
+++ b/plugins/stack/python/formatters.ts
@@ -1,0 +1,51 @@
+import { IntrospectFn } from "../deps.ts";
+import {
+  introspect as instrospectBlack,
+  Black,
+} from "./black.ts"
+import {
+  introspect as instrospectIsort,
+  Isort,
+} from "./isort.ts"
+
+
+export type Formatters = {
+  black?: Black | null;
+  isort?: Isort | null;
+} | null;
+
+function anyValue(records: Record<string, unknown>): boolean {
+  return Object.values(records).some((v) => v);
+}
+
+export const introspect: IntrospectFn<Formatters> = async (context) => {
+  const logger = context.getLogger("python");
+  logger.debug("detecting formatter");
+
+  const black = await instrospectBlack(context);
+  if (black !== null) {
+    logger.debug("detected Black");
+  }
+  const isort = await instrospectIsort(context);
+  if (isort !== null) {
+    logger.debug("detected Isort");
+  }
+
+  const formatters: Formatters = {
+    black,
+    isort,
+  };
+
+  if (anyValue(formatters)) return formatters;
+
+  if (context.suggestDefault) {
+    logger.warning("No Python formatter detected, using Black and Isort");
+    return {
+      black: { hasBlack: false},
+      isort: { hasIsort: false},
+    };
+  }
+
+  logger.debug("no supported formatter detected");
+  return null;
+};

--- a/plugins/stack/python/isort.ts
+++ b/plugins/stack/python/isort.ts
@@ -1,50 +1,12 @@
 import { IntrospectFn } from "../deps.ts";
+import { hasDependency } from "./utils.ts";
 
 export interface Isort {
   hasIsort: boolean;
 }
 
 export const introspect: IntrospectFn<Isort | null> = async (context) => {
-  for await (const file of context.files.each("**/pyproject.toml")) {
-    const pyproject = await context.files.readToml(file.path);
-    const libs = {
-      ...(pyproject?.tool || {}),
-      ...(pyproject?.tool.poetry.dependencies || {}),
-      ...(pyproject?.tool.poetry["dev-dependencies"] || {}),
-    };
-    const hasIsort = Object.keys(libs).some((name) =>
-      name === "isort"
-    );
-    if (hasIsort) {
-      return {
-        "hasIsort": true,
-      };
-    }
-  }
-  for await (const file of context.files.each("**/Pipfile")) {
-    const pipfile = await context.files.readToml(file.path);
-    const libs = {
-      ...(pipfile?.packages || {}),
-      ...(pipfile?.["dev-packages"] || {}),
-    };
-    const hasIsort = Object.keys(libs).some((name) =>
-      name === "isort"
-    );
-    if (hasIsort) {
-      return {
-        "hasIsort": true,
-      };
-    }
-  }
-  for await (const file of context.files.each("**/requirements.txt")) {
-    const requirements = await Deno.readTextFile(file.path);
-    if (requirements.includes("isort")) {
-      return {
-        "hasIsort": true,
-      };
-    }
-  }
   return {
-    "hasIsort": false,
+    hasIsort: await hasDependency("isort", context),
   };
 };

--- a/plugins/stack/python/isort.ts
+++ b/plugins/stack/python/isort.ts
@@ -1,0 +1,50 @@
+import { IntrospectFn } from "../deps.ts";
+
+export interface Isort {
+  hasIsort: boolean;
+}
+
+export const introspect: IntrospectFn<Isort | null> = async (context) => {
+  for await (const file of context.files.each("**/pyproject.toml")) {
+    const pyproject = await context.files.readToml(file.path);
+    const libs = {
+      ...(pyproject?.tool || {}),
+      ...(pyproject?.tool.poetry.dependencies || {}),
+      ...(pyproject?.tool.poetry["dev-dependencies"] || {}),
+    };
+    const hasIsort = Object.keys(libs).some((name) =>
+      name === "isort"
+    );
+    if (hasIsort) {
+      return {
+        "hasIsort": true,
+      };
+    }
+  }
+  for await (const file of context.files.each("**/Pipfile")) {
+    const pipfile = await context.files.readToml(file.path);
+    const libs = {
+      ...(pipfile?.packages || {}),
+      ...(pipfile?.["dev-packages"] || {}),
+    };
+    const hasIsort = Object.keys(libs).some((name) =>
+      name === "isort"
+    );
+    if (hasIsort) {
+      return {
+        "hasIsort": true,
+      };
+    }
+  }
+  for await (const file of context.files.each("**/requirements.txt")) {
+    const requirements = await Deno.readTextFile(file.path);
+    if (requirements.includes("isort")) {
+      return {
+        "hasIsort": true,
+      };
+    }
+  }
+  return {
+    "hasIsort": false,
+  };
+};

--- a/plugins/stack/python/linters.ts
+++ b/plugins/stack/python/linters.ts
@@ -1,0 +1,36 @@
+import { IntrospectFn } from "../deps.ts";
+import { Flake8, introspect as instrospectFlake8 } from "./flake8.ts";
+
+export type Linters = {
+  flake8?: Flake8 | null;
+} | null;
+
+function anyValue(records: Record<string, unknown>): boolean {
+  return Object.values(records).some((v) => v);
+}
+
+export const introspect: IntrospectFn<Linters> = async (context) => {
+  const logger = context.getLogger("python");
+  logger.debug("detecting linter");
+
+  const flake8 = await instrospectFlake8(context);
+  if (flake8 !== null) {
+    logger.debug("detected Flake8");
+  }
+
+  const linters: Linters = {
+    flake8,
+  };
+
+  if (anyValue(linters)) return linters;
+
+  if (context.suggestDefault) {
+    logger.warning("No Python linter detected, using Flake8");
+    return {
+      flake8: { hasFlake8: false },
+    };
+  }
+
+  logger.debug("no supported linter detected");
+  return null;
+};

--- a/plugins/stack/python/mod.ts
+++ b/plugins/stack/python/mod.ts
@@ -13,6 +13,10 @@ import {
   Isort,
 } from "./isort.ts"
 import {
+  introspect as instrospectPytest,
+  Pytest,
+} from "./pytest.ts"
+import {
   introspect as instrospectFlake8,
   Flake8,
 } from "./flake8.ts"
@@ -23,6 +27,8 @@ type PythonPackageManager = PackageManager | null
 // Available code formatters
 type BlackFormatter = Black | null
 type IsortFormatter = Isort | null
+// Available code tester
+type PytestTester = Pytest | null
 // Available Linter
 type Flake8Linter = Flake8 | null
 
@@ -58,6 +64,9 @@ export const introspector: Introspector<PythonProject | undefined> = {
     logger.debug("detecting formatter");
     const black = await instrospectBlack(context)
     const isort = await instrospectIsort(context)
+    // Tester
+    logger.debug("detecting tester");
+    const pytest = await instrospectPytest(context)
     // Linter
     logger.debug("detecting linter");
     const flake8 = await instrospectFlake8(context)
@@ -66,6 +75,7 @@ export const introspector: Introspector<PythonProject | undefined> = {
       pythonPackageManager: packageManager,
       blackFormatter: black,
       isortFormatter: isort,
+      pytestTester: pytest,
       flake8Linter: flake8,
     };
   },

--- a/plugins/stack/python/mod.ts
+++ b/plugins/stack/python/mod.ts
@@ -1,5 +1,19 @@
 import { Introspector } from "../deps.ts";
 import { introspect as introspectVersion } from "./version.ts";
+import {
+  introspect as introspectPackageManager,
+  PackageManager,
+} from "./package_manager.ts";
+import {
+  introspect as instrospectFlake8,
+  Flake8,
+} from "./flake8.ts"
+
+
+// Available package managers
+type PythonPackageManager = PackageManager | null
+// Available Linter
+type Flake8Linter = Flake8 | null
 
 /**
  * Introspected information about a project with Python
@@ -26,8 +40,16 @@ export const introspector: Introspector<PythonProject | undefined> = {
       return undefined;
     }
     logger.debug(`detected version ${version}`);
+    // Package Manager
+    logger.debug("detecting package manager");
+    const packageManager = await introspectPackageManager(context)
+    // Linter
+    logger.debug("detecting linter");
+    const flake8 = await instrospectFlake8(context)
     return {
       version: version,
+      pythonPackageManager: packageManager,
+      flake8Linter: flake8,
     };
   },
 };

--- a/plugins/stack/python/mod.ts
+++ b/plugins/stack/python/mod.ts
@@ -5,6 +5,14 @@ import {
   PackageManager,
 } from "./package_manager.ts";
 import {
+  introspect as instrospectBlack,
+  Black,
+} from "./black.ts"
+import {
+  introspect as instrospectIsort,
+  Isort,
+} from "./isort.ts"
+import {
   introspect as instrospectFlake8,
   Flake8,
 } from "./flake8.ts"
@@ -12,6 +20,9 @@ import {
 
 // Available package managers
 type PythonPackageManager = PackageManager | null
+// Available code formatters
+type BlackFormatter = Black | null
+type IsortFormatter = Isort | null
 // Available Linter
 type Flake8Linter = Flake8 | null
 
@@ -43,12 +54,18 @@ export const introspector: Introspector<PythonProject | undefined> = {
     // Package Manager
     logger.debug("detecting package manager");
     const packageManager = await introspectPackageManager(context)
+    // Formatter
+    logger.debug("detecting formatter");
+    const black = await instrospectBlack(context)
+    const isort = await instrospectIsort(context)
     // Linter
     logger.debug("detecting linter");
     const flake8 = await instrospectFlake8(context)
     return {
       version: version,
       pythonPackageManager: packageManager,
+      blackFormatter: black,
+      isortFormatter: isort,
       flake8Linter: flake8,
     };
   },

--- a/plugins/stack/python/mod.ts
+++ b/plugins/stack/python/mod.ts
@@ -1,45 +1,27 @@
 import { Introspector } from "../deps.ts";
 import { introspect as introspectVersion } from "./version.ts";
+import { introspect as instrospectLinter, Linters } from "./linters.ts";
+import {
+  Formatters,
+  introspect as instrospectFormatter,
+} from "./formatters.ts";
+import { introspect as instrospectTester, Testers } from "./testers.ts";
 import {
   introspect as introspectPackageManager,
   PackageManager,
 } from "./package_manager.ts";
-import {
-  introspect as instrospectBlack,
-  Black,
-} from "./black.ts"
-import {
-  introspect as instrospectIsort,
-  Isort,
-} from "./isort.ts"
-import {
-  introspect as instrospectPytest,
-  Pytest,
-} from "./pytest.ts"
-import {
-  introspect as instrospectFlake8,
-  Flake8,
-} from "./flake8.ts"
-
 
 // Available package managers
-type PythonPackageManager = PackageManager | null
-// Available code formatters
-type BlackFormatter = Black | null
-type IsortFormatter = Isort | null
-// Available code tester
-type PytestTester = Pytest | null
-// Available Linter
-type Flake8Linter = Flake8 | null
-
+type PythonPackageManager = PackageManager | null;
 /**
  * Introspected information about a project with Python
  */
 export default interface PythonProject {
-  /**
-   * Python version
-   */
   version?: string;
+  packageManager: PythonPackageManager;
+  linters: Linters | null;
+  formatters: Formatters | null;
+  testers: Testers | null;
 }
 
 export const introspector: Introspector<PythonProject | undefined> = {
@@ -59,24 +41,19 @@ export const introspector: Introspector<PythonProject | undefined> = {
     logger.debug(`detected version ${version}`);
     // Package Manager
     logger.debug("detecting package manager");
-    const packageManager = await introspectPackageManager(context)
+    const packageManager = await introspectPackageManager(context);
     // Formatter
-    logger.debug("detecting formatter");
-    const black = await instrospectBlack(context)
-    const isort = await instrospectIsort(context)
+    const formatters = await instrospectFormatter(context);
     // Tester
-    logger.debug("detecting tester");
-    const pytest = await instrospectPytest(context)
+    const testers = await instrospectTester(context);
     // Linter
-    logger.debug("detecting linter");
-    const flake8 = await instrospectFlake8(context)
+    const linters = await instrospectLinter(context);
     return {
-      version: version,
-      pythonPackageManager: packageManager,
-      blackFormatter: black,
-      isortFormatter: isort,
-      pytestTester: pytest,
-      flake8Linter: flake8,
+      version,
+      packageManager,
+      linters,
+      formatters,
+      testers,
     };
   },
 };

--- a/plugins/stack/python/package_manager.ts
+++ b/plugins/stack/python/package_manager.ts
@@ -1,0 +1,56 @@
+import { IntrospectFn } from "../deps.ts";
+
+interface Pip {
+  name: "pip",
+  dependenciesCommand: "pip install -r requirements.txt",
+  installCommand: "pip install",
+  runCommand: "";
+}
+
+interface Poetry {
+  name: "poetry",
+  dependenciesCommand: "poetry install",
+  installCommand: "poetry add",
+  runCommand: "poetry run";
+}
+
+interface Pipenv {
+  name: "pipenv",
+  dependenciesCommand: "pipenv install",
+  installCommand: "pipenv install",
+  runCommand: "pipenv run";
+}
+
+export type PackageManager = Pip | Poetry | Pipenv;
+
+export const introspect: IntrospectFn<PackageManager> = async (context) => {
+  if (await context.files.includes("**/pyproject.toml")) {
+    for await (const file of context.files.each("**/pyproject.toml")) {
+      const content = await Deno.readTextFile(file.path)
+      if (content.includes("poetry")) {
+        return {
+          name: "poetry",
+          dependenciesCommand: "poetry install",
+          installCommand: "poetry add",
+          runCommand: "poetry run"
+        }
+      }
+    }
+  }
+
+  if (await context.files.includes("**/Pipfile")){
+    return {
+      name: "pipenv",
+      dependenciesCommand: "pipenv install",
+      installCommand: "pipenv install",
+      runCommand: "pipenv run"
+    }
+  }
+
+  return {
+    name: "pip",
+    dependenciesCommand: "pip install -r requirements.txt",
+    installCommand: "pip install",
+    runCommand: ""
+  }
+};

--- a/plugins/stack/python/pytest.ts
+++ b/plugins/stack/python/pytest.ts
@@ -1,0 +1,50 @@
+import { IntrospectFn } from "../deps.ts";
+
+export interface Pytest {
+  hasPytest: boolean;
+}
+
+export const introspect: IntrospectFn<Pytest | null> = async (context) => {
+  for await (const file of context.files.each("**/pyproject.toml")) {
+    const pyproject = await context.files.readToml(file.path);
+    const libs = {
+      ...(pyproject?.tool || {}),
+      ...(pyproject?.tool.poetry.dependencies || {}),
+      ...(pyproject?.tool.poetry["dev-dependencies"] || {}),
+    };
+    const hasPytest = Object.keys(libs).some((name) =>
+      name === "pytest"
+    );
+    if (hasPytest) {
+      return {
+        "hasPytest": true,
+      };
+    }
+  }
+  for await (const file of context.files.each("**/Pipfile")) {
+    const pipfile = await context.files.readToml(file.path);
+    const libs = {
+      ...(pipfile?.packages || {}),
+      ...(pipfile?.["dev-packages"] || {}),
+    };
+    const hasPytest = Object.keys(libs).some((name) =>
+      name === "pytest"
+    );
+    if (hasPytest) {
+      return {
+        "hasPytest": true,
+      };
+    }
+  }
+  for await (const file of context.files.each("**/requirements.txt")) {
+    const requirements = await Deno.readTextFile(file.path);
+    if (requirements.includes("pytest")) {
+      return {
+        "hasPytest": true,
+      };
+    }
+  }
+  return {
+    "hasPytest": false,
+  };
+};

--- a/plugins/stack/python/pytest.ts
+++ b/plugins/stack/python/pytest.ts
@@ -1,50 +1,12 @@
 import { IntrospectFn } from "../deps.ts";
+import { hasDependency } from "./utils.ts";
 
 export interface Pytest {
   hasPytest: boolean;
 }
 
 export const introspect: IntrospectFn<Pytest | null> = async (context) => {
-  for await (const file of context.files.each("**/pyproject.toml")) {
-    const pyproject = await context.files.readToml(file.path);
-    const libs = {
-      ...(pyproject?.tool || {}),
-      ...(pyproject?.tool.poetry.dependencies || {}),
-      ...(pyproject?.tool.poetry["dev-dependencies"] || {}),
-    };
-    const hasPytest = Object.keys(libs).some((name) =>
-      name === "pytest"
-    );
-    if (hasPytest) {
-      return {
-        "hasPytest": true,
-      };
-    }
-  }
-  for await (const file of context.files.each("**/Pipfile")) {
-    const pipfile = await context.files.readToml(file.path);
-    const libs = {
-      ...(pipfile?.packages || {}),
-      ...(pipfile?.["dev-packages"] || {}),
-    };
-    const hasPytest = Object.keys(libs).some((name) =>
-      name === "pytest"
-    );
-    if (hasPytest) {
-      return {
-        "hasPytest": true,
-      };
-    }
-  }
-  for await (const file of context.files.each("**/requirements.txt")) {
-    const requirements = await Deno.readTextFile(file.path);
-    if (requirements.includes("pytest")) {
-      return {
-        "hasPytest": true,
-      };
-    }
-  }
   return {
-    "hasPytest": false,
+    hasPytest: await hasDependency("pytest", context),
   };
 };

--- a/plugins/stack/python/testers.ts
+++ b/plugins/stack/python/testers.ts
@@ -1,0 +1,39 @@
+import { IntrospectFn } from "../deps.ts";
+import {
+  introspect as instrospectPytest,
+  Pytest,
+} from "./pytest.ts"
+
+export type Testers = {
+  pytest?: Pytest | null;
+} | null;
+
+function anyValue(records: Record<string, unknown>): boolean {
+  return Object.values(records).some((v) => v);
+}
+
+export const introspect: IntrospectFn<Testers> = async (context) => {
+  const logger = context.getLogger("python");
+  logger.debug("detecting tester");
+
+  const pytest = await instrospectPytest(context);
+  if (pytest !== null) {
+    logger.debug("detected Pytest");
+  }
+
+  const testers: Testers = {
+    pytest,
+  };
+
+  if (anyValue(testers)) return testers;
+
+  if (context.suggestDefault) {
+    logger.warning("No Python tester detected, using Pytest");
+    return {
+      pytest: { hasPytest: false},
+    };
+  }
+
+  logger.debug("no supported tester detected");
+  return null;
+};

--- a/plugins/stack/python/utils.ts
+++ b/plugins/stack/python/utils.ts
@@ -1,0 +1,37 @@
+import { Context } from "../../../src/plugin/mod.ts";
+
+export async function hasDependency(
+  dependency: string,
+  context: Context,
+) {
+  for await (const file of context.files.each("**/pyproject.toml")) {
+    const pyproject = await context.files.readToml(file.path);
+    const libs = {
+      ...(pyproject?.tool || {}),
+      ...(pyproject?.tool.poetry.dependencies || {}),
+      ...(pyproject?.tool.poetry["dev-dependencies"] || {}),
+    };
+    const hasDep = Object.keys(libs).some((name) => name === dependency);
+    if (hasDep) {
+      return true;
+    }
+  }
+  for await (const file of context.files.each("**/Pipfile")) {
+    const pipfile = await context.files.readToml(file.path);
+    const libs = {
+      ...(pipfile?.packages || {}),
+      ...(pipfile?.["dev-packages"] || {}),
+    };
+    const hasDep = Object.keys(libs).some((name) => name === dependency);
+    if (hasDep) {
+      return true;
+    }
+  }
+  for await (const file of context.files.each("**/requirements.txt")) {
+    const requirements = await Deno.readTextFile(file.path);
+    if (requirements.includes(dependency)) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/templates/github/python/format.yaml
+++ b/templates/github/python/format.yaml
@@ -1,0 +1,33 @@
+name: Format Python
+on:
+  pull_request:
+    paths:
+      - "**.py"
+jobs:
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: <%= it.version %>
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install <%= it.pythonPackageManager.name %>
+          <%= it.pythonPackageManager.dependenciesCommand %>
+
+      <%_ if (!it.blackFormatter.hasBlack) { %>
+      - name: Install black
+        run: pip install black
+      <%_ } -%>
+
+      - run: <%= it.pythonPackageManager.runCommand %> black . --check
+
+      <%_ if (!it.isortFormatter.hasIsort) { %>
+      - name: Install Isort
+        run: pip install isort
+      <%_ } -%>
+
+      - run: <%= it.pythonPackageManager.runCommand %> isort . --check-only

--- a/templates/github/python/format.yaml
+++ b/templates/github/python/format.yaml
@@ -15,19 +15,19 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install <%= it.pythonPackageManager.name %>
-          <%= it.pythonPackageManager.dependenciesCommand %>
+          pip install <%= it.packageManager.name %>
+          <%= it.packageManager.dependenciesCommand %>
 
-      <%_ if (!it.blackFormatter.hasBlack) { %>
+      <%_ if (!it.formatters.black.hasBlack) { %>
       - name: Install black
         run: pip install black
       <%_ } -%>
 
-      - run: <%= it.pythonPackageManager.runCommand %> black . --check
+      - run: <%= it.packageManager.runCommand %> black . --check
 
-      <%_ if (!it.isortFormatter.hasIsort) { %>
+      <%_ if (!it.formatters.isort.hasIsort) { %>
       - name: Install Isort
         run: pip install isort
       <%_ } -%>
 
-      - run: <%= it.pythonPackageManager.runCommand %> isort . --check-only
+      - run: <%= it.packageManager.runCommand %> isort . --check-only

--- a/templates/github/python/lint.yaml
+++ b/templates/github/python/lint.yaml
@@ -12,12 +12,12 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install <%= it.pythonPackageManager.name %>
-          <%= it.pythonPackageManager.dependenciesCommand %>
+          pip install <%= it.packageManager.name %>
+          <%= it.packageManager.dependenciesCommand %>
 
-        <%_ if (!it.flake8Linter.hasFlake8) { %>
+        <%_ if (!it.linters.flake8.hasFlake8) { %>
       - name: Install Flake8
         run: pip install flake8
       <%_ } -%>
 
-      - run: <%= it.pythonPackageManager.runCommand %> flake8
+      - run: <%= it.packageManager.runCommand %> flake8

--- a/templates/github/python/lint.yaml
+++ b/templates/github/python/lint.yaml
@@ -9,5 +9,15 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: <%= it.version %>
-      - run: python -m pip install flake8
-      - run: flake8
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install <%= it.pythonPackageManager.name %>
+          <%= it.pythonPackageManager.dependenciesCommand %>
+
+        <%_ if (!it.flake8Linter.hasFlake8) { %>
+      - name: Install Flake8
+        run: pip install flake8
+      <%_ } -%>
+
+      - run: <%= it.pythonPackageManager.runCommand %> flake8

--- a/templates/github/python/test.yaml
+++ b/templates/github/python/test.yaml
@@ -1,0 +1,26 @@
+name: Test Python
+on:
+  pull_request:
+    paths:
+      - "**.py"
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: <%= it.version %>
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install <%= it.pythonPackageManager.name %>
+          <%= it.pythonPackageManager.dependenciesCommand %>
+
+        <%_ if (!it.pytestTester.hasPytest) { %>
+      - name: Install Pytest
+        run: pip install pytest
+      <%_ } -%>
+
+      - run: <%= it.pythonPackageManager.runCommand %> pytest

--- a/templates/github/python/test.yaml
+++ b/templates/github/python/test.yaml
@@ -15,12 +15,12 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install <%= it.pythonPackageManager.name %>
-          <%= it.pythonPackageManager.dependenciesCommand %>
+          pip install <%= it.packageManager.name %>
+          <%= it.packageManager.dependenciesCommand %>
 
-        <%_ if (!it.pytestTester.hasPytest) { %>
+        <%_ if (!it.testers.pytest.hasPytest) { %>
       - name: Install Pytest
         run: pip install pytest
       <%_ } -%>
 
-      - run: <%= it.pythonPackageManager.runCommand %> pytest
+      - run: <%= it.packageManager.runCommand %> pytest


### PR DESCRIPTION
# Description
This PR augments the Python stack plugins with the Format, Test, and Linter stages. Also adds dependency manager checking.

# Details
Package Manager: Check the project dependencies file to identify the type of package manager used, this makes it possible to install the project's dependencies into the pipeline. This PR implements support for:
	- Pipfile
	- pyproject.toml
	- requirements.txt

Format: Adds code formatting plugin, which will check if the user has `black` and `isort` installed, if not, performs the installation and runs in the pipeline.

Linter: Adds code linter plugin, which will check if the user has `flake8` installed, if not, performs the installation and runs in the pipeline.

Test: Adds plugin that checks if the user has `pytest` installed, if not, installs and runs during the pipeline.

# Test
Test performed in the nameko-vault project of github-instruct, where a pipeline was generated with pipelinit with the stages: Lint, Format, and Test.
The generated files are set to run on every pull_request and only when files with the .py extension are changed.

ref: #10 

![image](https://user-images.githubusercontent.com/50335822/130848715-f779cbf8-1c65-4bce-a5e9-77779a280c3b.png)
![image](https://user-images.githubusercontent.com/50335822/130848794-7657e25e-f82b-4b8a-a008-e173082fb811.png)
