### PR TITLE
Include a header in generated  files

### DIFF
--- a/plugins/platforms/github/mod.test.ts
+++ b/plugins/platforms/github/mod.test.ts
@@ -25,7 +25,7 @@ jobs:
 `;
 
 const fakeYamlWithHeader = `# Generated with pipelinit ${FAKE_VERSION}
-# https://www.pipelinit.com/
+# https://pipelinit.com/
 ${fakeYaml}`;
 
 Deno.test("Plugins > GitHub - prepends a header to generated files", async () => {

--- a/plugins/platforms/github/mod.test.ts
+++ b/plugins/platforms/github/mod.test.ts
@@ -1,0 +1,48 @@
+import { context } from "../../../src/plugin/mod.ts";
+import { assertEquals, deepMerge } from "../../../deps.ts";
+import { RenderedTemplate } from "../../../src/platform/plugin.ts";
+
+import { github } from "./mod.ts";
+
+const FAKE_VERSION = "v10.10.10";
+
+// FIXME
+// This doesn't work:
+// deepMerge(context, { version: FAKE_VERSION });
+// Why?
+const fakeContext = deepMerge(context, {});
+fakeContext.version = FAKE_VERSION;
+
+const fakeYaml = `
+name: Runner check
+on: pull_request
+jobs:
+  stage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: ls
+`;
+
+const fakeYamlWithHeader = `# Generated with pipelinit ${FAKE_VERSION}
+# https://www.pipelinit.com/
+${fakeYaml}`;
+
+Deno.test("Plugins > GitHub - prepends a header to generated files", async () => {
+  async function* templatesFixture(): AsyncIterableIterator<RenderedTemplate> {
+    yield {
+      name: "pipelinit.stage",
+      content: fakeYaml,
+    };
+    return;
+  }
+  const result = await github(fakeContext, templatesFixture());
+  assertEquals(result.length, 1);
+  assertEquals(
+    result,
+    [{
+      path: ".github/workflows/pipelinit.stage.yaml",
+      content: fakeYamlWithHeader,
+    }],
+  );
+});

--- a/plugins/platforms/github/mod.ts
+++ b/plugins/platforms/github/mod.ts
@@ -1,12 +1,16 @@
-import { ensureFile, log, PlatformWriterFn } from "../deps.ts";
+import { ensureFile, PlatformWriterFn } from "../deps.ts";
 
-export const github: PlatformWriterFn = async (templates) => {
-  const logger = log.getLogger("main");
+export const github: PlatformWriterFn = async (context, templates) => {
+  const logger = context.getLogger("main");
+  const header = `
+# Generated with pipelinit ${context.version}
+# https://www.pipelinit.com/
+`.trimStart();
   for await (const template of templates) {
     const { name, content } = template;
     const filename = `.github/workflows/${name}.yaml`;
     logger.info(`Writing ${filename}`);
     await ensureFile(filename);
-    await Deno.writeTextFile(filename, content);
+    await Deno.writeTextFile(filename, `${header}${content}`);
   }
 };

--- a/plugins/platforms/github/mod.ts
+++ b/plugins/platforms/github/mod.ts
@@ -3,7 +3,7 @@ import { PlatformWriterFn } from "../deps.ts";
 export const github: PlatformWriterFn = async (context, templates) => {
   const header = `
 # Generated with pipelinit ${context.version}
-# https://www.pipelinit.com/
+# https://pipelinit.com/
 `.trimStart();
   const configurationFiles = [];
   for await (const template of templates) {

--- a/plugins/platforms/github/mod.ts
+++ b/plugins/platforms/github/mod.ts
@@ -1,16 +1,17 @@
-import { ensureFile, PlatformWriterFn } from "../deps.ts";
+import { PlatformWriterFn } from "../deps.ts";
 
 export const github: PlatformWriterFn = async (context, templates) => {
-  const logger = context.getLogger("main");
   const header = `
 # Generated with pipelinit ${context.version}
 # https://www.pipelinit.com/
 `.trimStart();
+  const configurationFiles = [];
   for await (const template of templates) {
     const { name, content } = template;
-    const filename = `.github/workflows/${name}.yaml`;
-    logger.info(`Writing ${filename}`);
-    await ensureFile(filename);
-    await Deno.writeTextFile(filename, `${header}${content}`);
+    configurationFiles.push({
+      path: `.github/workflows/${name}.yaml`,
+      content: `${header}${content}`,
+    });
   }
+  return configurationFiles;
 };

--- a/src/cli/commands/default.ts
+++ b/src/cli/commands/default.ts
@@ -4,6 +4,7 @@ import { renderTemplates } from "../../template/mod.ts";
 import { prelude } from "../prelude/mod.ts";
 import { GlobalOptions } from "../types.ts";
 import { outputErrors } from "../../plugin/errors.ts";
+import { context } from "../../plugin/mod.ts";
 
 type DefaultOptions = GlobalOptions;
 
@@ -12,6 +13,7 @@ export default async function (opts: DefaultOptions): Promise<void> {
   const detected = await introspect();
   const platform = "github";
   await platformWriters[platform](
+    context,
     renderTemplates(platform, detected),
   );
   outputErrors();

--- a/src/cli/commands/default.ts
+++ b/src/cli/commands/default.ts
@@ -5,16 +5,23 @@ import { prelude } from "../prelude/mod.ts";
 import { GlobalOptions } from "../types.ts";
 import { outputErrors } from "../../plugin/errors.ts";
 import { context } from "../../plugin/mod.ts";
+import { ensureFile } from "../../../deps.ts";
 
 type DefaultOptions = GlobalOptions;
 
 export default async function (opts: DefaultOptions): Promise<void> {
   await prelude(opts);
+  const logger = context.getLogger("main");
   const detected = await introspect();
   const platform = "github";
-  await platformWriters[platform](
+  const files = await platformWriters[platform](
     context,
     renderTemplates(platform, detected),
   );
+  for (const { path, content } of files) {
+    logger.info(`Writing ${path}`);
+    await ensureFile(path);
+    await Deno.writeTextFile(path, content);
+  }
   outputErrors();
 }

--- a/src/platform/plugin.ts
+++ b/src/platform/plugin.ts
@@ -1,8 +1,11 @@
+import { Context } from "../plugin/mod.ts";
+
 export interface RenderedTemplate {
   name: string;
   content: string;
 }
 
 export type PlatformWriterFn = (
+  context: Context,
   templates: AsyncIterableIterator<RenderedTemplate>,
 ) => Promise<void>;

--- a/src/platform/plugin.ts
+++ b/src/platform/plugin.ts
@@ -5,7 +5,12 @@ export interface RenderedTemplate {
   content: string;
 }
 
+export interface CiConfigurationFile {
+  path: string;
+  content: string;
+}
+
 export type PlatformWriterFn = (
   context: Context,
   templates: AsyncIterableIterator<RenderedTemplate>,
-) => Promise<void>;
+) => Promise<Array<CiConfigurationFile>>;

--- a/src/plugin/mod.ts
+++ b/src/plugin/mod.ts
@@ -1,6 +1,7 @@
+import { log, semver } from "../../deps.ts";
 import { each, includes, readJSON, readLines, readToml } from "./files.ts";
 import { errors } from "./errors.ts";
-import { log, semver } from "../../deps.ts";
+import { VERSION } from "../version.ts";
 
 export const context = {
   getLogger: log.getLogger,
@@ -16,6 +17,7 @@ export const context = {
   },
   semver,
   suggestDefault: true,
+  version: VERSION,
 };
 
 export type Context = typeof context;


### PR DESCRIPTION
Add a header with the version used when the files were generated.
An user can compare the latest available version with the version in the CI files to decide if they need to update.