### PR TITLE
Add docker stack and complement existing

### DIFF
--- a/.github/workflows/pipelinit.javascript.format.yaml
+++ b/.github/workflows/pipelinit.javascript.format.yaml
@@ -1,3 +1,5 @@
+# Generated with pipelinit 0.1.0-rc.3
+# https://pipelinit.com/
 name: Format Deno
 on:
   pull_request:
@@ -5,7 +7,7 @@ on:
       - '**.js'
       - '**.ts'
 jobs:
-  lint:
+  format:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/pipelinit.javascript.lint.yaml
+++ b/.github/workflows/pipelinit.javascript.lint.yaml
@@ -1,3 +1,5 @@
+# Generated with pipelinit 0.1.0-rc.3
+# https://pipelinit.com/
 name: Lint Deno
 on:
   pull_request:

--- a/.github/workflows/pipelinit.javascript.test.yaml
+++ b/.github/workflows/pipelinit.javascript.test.yaml
@@ -1,3 +1,5 @@
+# Generated with pipelinit 0.1.0-rc.3
+# https://pipelinit.com/
 name: Test Deno
 on:
   pull_request:
@@ -5,7 +7,7 @@ on:
       - '**.js'
       - '**.ts'
 jobs:
-  lint:
+  test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ pipelinit
 
 ## Examples
 
-You can see the generated pipelines running by your through our sample projects for each stack:
+You can see the generated pipelines that ran, through our sample projects for the following stacks:
 
 - [Python Django](https://github.com/pipelinit/pipelinit-sample-python/pulls)
 - [Docker](https://github.com/pipelinit/pipelinit-sample-docker/pulls)

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ Say goodbye to YAML!
       <td rowspan="2">CSS</td>
       <td>Format</td>
       <td>✔️</td>
-      <td rowspan="8">Coming soon</td>
-      <td rowspan="8">Coming soon</td>
+      <td rowspan="13">Coming soon</td>
+      <td rowspan="13">Coming soon</td>
     </tr>
     <tr>
       <td>Lint</td>
@@ -46,7 +46,7 @@ Say goodbye to YAML!
       <td>✔️</td>
     </tr>
     <tr>
-      <td rowspan="3">JavaScript</td>
+      <td rowspan="3">JavaScript / Typescript</td>
       <td>Format</td>
       <td>✔️</td>
     </tr>
@@ -56,11 +56,33 @@ Say goodbye to YAML!
     </tr>
     <tr>
       <td>Test</td>
-      <td>Deno (Node.js comming soon)</td>
+      <td>✔️</td>
     </tr>
     <tr>
-      <td>Python</td>
+      <td rowspan="3">Python</td>
       <td>Lint</td>
+      <td>✔️</td>
+    </tr>
+    <tr>
+      <td>Format</td>
+      <td>✔️</td>
+    </tr>
+    <tr>
+      <td>Test</td>
+      <td>✔️</td>
+    </tr>
+    <tr>
+      <td rowspan="2">Docker</td>
+      <td>Lint</td>
+      <td>✔️</td>
+    </tr>
+    <tr>
+      <td>Build</td>
+      <td>✔️</td>
+    </tr>
+    <tr>
+      <td rowspan="2">Java</td>
+      <td>Build (Gradle)</td>
       <td>✔️</td>
     </tr>
   </tbody>
@@ -90,6 +112,15 @@ instructions:
 ```
 pipelinit
 ```
+
+## Examples
+
+You can see the generated pipelines running by your through our sample projects for each stack:
+
+- [Python Django](https://github.com/pipelinit/pipelinit-sample-python/pulls)
+- [Docker](https://github.com/pipelinit/pipelinit-sample-docker/pulls)
+- [Vue](https://github.com/pipelinit/pipelinit-sample-vue-html/pulls)
+- [Java with Gradle](https://github.com/pipelinit/pipelinit-sample-java-gradle/pulls)
 
 ## Concepts
 
@@ -273,9 +304,10 @@ If this isn't desired, you can disable this with the flag `--no-default-stage`.
 
 #### Tools
 
-| Stage | Tools                               |
-| ----- | ----------------------------------- |
-| Lint  | [Flake8](https://flake8.pycqa.org/) |
+| Stage   | Tools                                |
+| ------  | ------------------------------------ |
+| Lint    | [Flake8](https://flake8.pycqa.org/) _default_  |
+| Format  | [Black](https://black.readthedocs.io/en/stable/) _default_
 
 ## Developmenting and contributing
 

--- a/core/plugins/stack/docker/mod.test.ts
+++ b/core/plugins/stack/docker/mod.test.ts
@@ -1,0 +1,28 @@
+import { context } from "../../../tests/mod.ts";
+import { assertEquals, deepMerge } from "../../../deps.ts";
+
+import { introspector } from "./mod.ts";
+
+Deno.test("Plugins > Check if Dockerfile is identified", async () => {
+  const fakeContext = deepMerge(
+    context,
+    {
+      files: {
+        // deno-lint-ignore require-await
+        includes: async (glob: string): Promise<boolean> => {
+          if (glob === "**/Dockerfile") {
+            return true;
+          }
+          return false;
+        },
+      },
+    },
+  );
+  const result = await introspector.introspect(
+    fakeContext,
+  );
+
+  assertEquals(result, {
+    hasDockerImage: true,
+  });
+});

--- a/core/plugins/stack/docker/mod.ts
+++ b/core/plugins/stack/docker/mod.ts
@@ -1,4 +1,4 @@
-import { Introspector } from "../deps.ts";
+import { Introspector } from "../../../types.ts";
 
 /**
  * Introspected information about a project with Docker

--- a/core/plugins/stack/docker/mod.ts
+++ b/core/plugins/stack/docker/mod.ts
@@ -1,0 +1,20 @@
+import { Introspector } from "../deps.ts";
+
+/**
+ * Introspected information about a project with Docker
+ */
+export default interface DockerProject {
+  hasDockerImage: true;
+}
+
+export const introspector: Introspector<DockerProject> = {
+  detect: async (context) => {
+    return await context.files.includes("./Dockerfile");
+  },
+  introspect: async (context) => {
+    const logger = await context.getLogger("docker");
+    logger.info("Found docker image on root");
+
+    return { hasDockerImage: true };
+  },
+};

--- a/core/plugins/stack/java/mod.test.ts
+++ b/core/plugins/stack/java/mod.test.ts
@@ -1,0 +1,28 @@
+import { context } from "../../../tests/mod.ts";
+import { assertEquals, deepMerge } from "../../../deps.ts";
+
+import { introspector } from "./mod.ts";
+
+Deno.test("Plugins > Check if Gradle build is identified", async () => {
+  const fakeContext = deepMerge(
+    context,
+    {
+      files: {
+        // deno-lint-ignore require-await
+        includes: async (glob: string): Promise<boolean> => {
+          if (glob === "**/build.gradle") {
+            return true;
+          }
+          return false;
+        },
+      },
+    },
+  );
+  const result = await introspector.introspect(
+    fakeContext,
+  );
+
+  assertEquals(result, {
+    isGradleProject: true,
+  });
+});

--- a/core/plugins/stack/java/mod.ts
+++ b/core/plugins/stack/java/mod.ts
@@ -1,0 +1,20 @@
+import { Introspector } from "../../../types.ts";
+
+/**
+ * Introspected information about a project with Docker
+ */
+export default interface JavaProject {
+  isGradleProject: true;
+}
+
+export const introspector: Introspector<JavaProject> = {
+  detect: async (context) => {
+    return await context.files.includes("**/build.gradle");
+  },
+  introspect: async (context) => {
+    const logger = await context.getLogger("java");
+    logger.info("Detected gradle project");
+
+    return { isGradleProject: true };
+  },
+};

--- a/core/plugins/stack/javascript/mod.test.ts
+++ b/core/plugins/stack/javascript/mod.test.ts
@@ -1,0 +1,73 @@
+import { context } from "../../../tests/mod.ts";
+import { assertEquals, deepMerge } from "../../../deps.ts";
+import { FileEntry } from "../../../types.ts";
+
+import { introspector } from "./mod.ts";
+
+Deno.test("Plugins > Check eslint and node for javascript project", async () => {
+  const fakeContext = deepMerge(
+    context,
+    {
+      files: {
+        // deno-lint-ignore require-await
+        includes: async (glob: string): Promise<boolean> => {
+          if (glob === "**/.eslintrc.{js,cjs,yaml,yml,json}") {
+            return true;
+          }
+          return false;
+        },
+        each: async function* (glob: string): AsyncIterableIterator<FileEntry> {
+          if (glob === "**/*.{html,vue}") {
+            yield {
+              name: "index.ts",
+              path: "fake-path",
+            };
+            yield {
+              name: "index.js",
+              path: "fake-path",
+            };
+          }
+          if (glob === "**/package.json") {
+            yield {
+              name: "package.json",
+              path: "fake-path",
+            };
+          }
+          if (glob === "**/.eslintrc.{js,cjs,yaml,yml,json}") {
+            yield {
+              name: ".eslintrc.js",
+              path: "fake-path",
+            };
+          }
+          if (glob === "**/.eslintignore") {
+            yield {
+              name: ".eslintignore",
+              path: "fake-path",
+            };
+          }
+          return;
+        },
+        // deno-lint-ignore require-await
+        readJSON: async (path: string): Promise<Record<string, unknown>> => {
+          const deps = { stylelint: "1.0.0", eslint: "7.2.2" };
+          if (path === "fake-path") {
+            return { devDependencies: deps };
+          }
+          return {};
+        },
+      },
+    },
+  );
+  const result = await introspector.introspect(
+    fakeContext,
+  );
+
+  assertEquals(result, {
+    runtime: { name: "node", version: "16" },
+    packageManager: { name: "npm" },
+    linters: {
+      eslint: { name: "eslint", hasIgnoreFile: false },
+    },
+    formatters: { prettier: { name: "prettier", hasIgnoreFile: false } },
+  });
+});

--- a/core/plugins/stack/mod.ts
+++ b/core/plugins/stack/mod.ts
@@ -2,23 +2,38 @@ import { introspector as CssIntrospector } from "./css/mod.ts";
 import { introspector as JavaScriptIntrospector } from "./javascript/mod.ts";
 import { introspector as PythonIntrospector } from "./python/mod.ts";
 import { introspector as HtmlIntrospector } from "./html/mod.ts";
+import { introspector as DockerIntrospector } from "./docker/mod.ts";
+import { introspector as JavaIntrospector } from "./java/mod.ts";
 
 import type CSSProject from "./css/mod.ts";
 import type JavaScriptProject from "./javascript/mod.ts";
 import type PythonProject from "./python/mod.ts";
 import type HtmlProject from "./html/mod.ts";
+import type DockerProject from "./docker/mod.ts";
+import type JavaProject from "./java/mod.ts";
 
 export type ProjectData =
   | CSSProject
   | JavaScriptProject
   | PythonProject
-  | HtmlProject;
+  | HtmlProject
+  | DockerProject
+  | JavaProject;
 
-export type { CSSProject, HtmlProject, JavaScriptProject, PythonProject };
+export type {
+  CSSProject,
+  DockerProject,
+  HtmlProject,
+  JavaProject,
+  JavaScriptProject,
+  PythonProject,
+};
 
 export const introspectors = [
+  { name: "docker", ...DockerIntrospector },
   { name: "css", ...CssIntrospector },
   { name: "javascript", ...JavaScriptIntrospector },
   { name: "python", ...PythonIntrospector },
   { name: "html", ...HtmlIntrospector },
+  { name: "java", ...JavaIntrospector },
 ];

--- a/core/plugins/stack/python/django.ts
+++ b/core/plugins/stack/python/django.ts
@@ -1,0 +1,9 @@
+import { IntrospectFn } from "../deps.ts";
+
+export const introspect: IntrospectFn<boolean> = async (context) => {
+  // Search for project manage.py to define as a Django project
+  for await (const _file of context.files.each("**/manage.py")) {
+    return true;
+  }
+  return false;
+};

--- a/core/plugins/stack/python/django.ts
+++ b/core/plugins/stack/python/django.ts
@@ -1,9 +1,6 @@
-import { IntrospectFn } from "../deps.ts";
+import { IntrospectFn } from "../../../types.ts";
 
 export const introspect: IntrospectFn<boolean> = async (context) => {
   // Search for project manage.py to define as a Django project
-  for await (const _file of context.files.each("**/manage.py")) {
-    return true;
-  }
-  return false;
+  return await context.files.includes("**/manage.py");
 };

--- a/core/plugins/stack/python/mod.test.ts
+++ b/core/plugins/stack/python/mod.test.ts
@@ -1,0 +1,49 @@
+import { context } from "../../../tests/mod.ts";
+import { assertEquals, deepMerge } from "../../../deps.ts";
+import { FileEntry } from "../../../types.ts";
+
+import { introspector } from "./mod.ts";
+
+Deno.test("Plugins > Check if python version and django project is identified", async () => {
+  const fakeContext = deepMerge(
+    context,
+    {
+      files: {
+        // deno-lint-ignore require-await
+        includes: async (glob: string): Promise<boolean> => {
+          if (glob === "**/*.py") {
+            return true;
+          }
+          if (glob === "**/manage.py") {
+            return true;
+          }
+          return false;
+        },
+        each: async function* (glob: string): AsyncIterableIterator<FileEntry> {
+          if (glob === "**/Pipfile") {
+            yield {
+              name: "Pipefile",
+              path: "fake-path",
+            };
+          }
+          return;
+        },
+        // deno-lint-ignore require-await
+        readToml: async (path: string): Promise<Record<string, unknown>> => {
+          if (path === "fake-path") {
+            return { requires: { python_version: "3.6" } };
+          }
+          return {};
+        },
+      },
+    },
+  );
+  const result = await introspector.introspect(
+    fakeContext,
+  );
+
+  assertEquals(result, {
+    version: "3.6",
+    django: true,
+  });
+});

--- a/core/plugins/stack/python/mod.ts
+++ b/core/plugins/stack/python/mod.ts
@@ -1,5 +1,6 @@
 import { Introspector } from "../../../types.ts";
 import { introspect as introspectVersion } from "./version.ts";
+import { introspect as introspectDjango } from "./django.ts";
 
 /**
  * Introspected information about a project with Python
@@ -9,6 +10,10 @@ export default interface PythonProject {
    * Python version
    */
   version?: string;
+  /**
+   * If is a Django project
+   */
+  django?: boolean;
 }
 
 export const introspector: Introspector<PythonProject | undefined> = {
@@ -26,8 +31,15 @@ export const introspector: Introspector<PythonProject | undefined> = {
       return undefined;
     }
     logger.debug(`detected version ${version}`);
+
+    // Django
+    const django = await introspectDjango(context);
+    if (django) {
+      logger.info("detected Django project");
+    }
     return {
       version: version,
+      django: django,
     };
   },
 };

--- a/core/templates/github/docker/build.yml
+++ b/core/templates/github/docker/build.yml
@@ -1,0 +1,15 @@
+name: Docker Image CI
+
+on:
+  pull_request:
+    paths:
+      - "Dockerfile"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build the Docker image
+        run: docker build . --file Dockerfile --tag image:$(date +%s)

--- a/core/templates/github/docker/lint.yml
+++ b/core/templates/github/docker/lint.yml
@@ -1,0 +1,16 @@
+name: Docker Image CI
+
+on:
+  pull_request:
+    paths:
+      - "Dockerfile"
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: hadolint/hadolint-action@v1.5.0
+        with:
+          dockerfile: Dockerfile

--- a/core/templates/github/java/build.yaml
+++ b/core/templates/github/java/build.yaml
@@ -1,0 +1,21 @@
+name: Build Java Project with Gradle
+on:
+  pull_request:
+    paths:
+      - "**.java"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: "11"
+          distribution: "adopt"
+          cache: gradle
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+      - name: Build with Gradle
+        run: ./gradlew build

--- a/core/templates/github/javascript/test.yaml
+++ b/core/templates/github/javascript/test.yaml
@@ -30,6 +30,10 @@ jobs:
         with:
           node-version: '<%= it.runtime.version %>'
           cache: '<%= it.packageManager.name %>'
-      - run: <%= it.packageManager.name %> ci
+<% if (it.packageManager.name === "npm") { -%>
+      - run: npm ci
+<% } else if (it.packageManager.name === "yarn") { -%>
+      - run: yarn
+<% } -%>
       - run: <%= it.packageManager.name %> test
 <% } -%>

--- a/core/templates/github/javascript/test.yaml
+++ b/core/templates/github/javascript/test.yaml
@@ -14,4 +14,22 @@ jobs:
         with:
           deno-version: v1.x
       - run: deno test --unstable --allow-all
+<% } else if (it.runtime.name === "node") { -%>
+name: Test Node
+on:
+  pull_request:
+    paths:
+      - '**.js'
+      - '**.ts'
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '<%= it.runtime.version %>'
+          cache: '<%= it.packageManager.name %>'
+      - run: <%= it.packageManager.name %> ci
+      - run: <%= it.packageManager.name %> test
 <% } -%>

--- a/core/templates/github/python/lint.yaml
+++ b/core/templates/github/python/lint.yaml
@@ -15,4 +15,6 @@ jobs:
 
       - run: python -m pip install pip flake8 black
       - run: black . --check
+      # Adapts Flake8 to run with the Black formatter, using the '--ignore' flag to skip incompatibilities errors
+      # Reference: https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html?highlight=other%20tools#id1
       - run: flake8 --ignore E203,E501,W503 .

--- a/core/templates/github/python/lint.yaml
+++ b/core/templates/github/python/lint.yaml
@@ -1,5 +1,8 @@
 name: Lint Python
-on: push
+on:
+  pull_request:
+    paths:
+      - "**.py"
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -9,5 +12,7 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: <%= it.version %>
-      - run: python -m pip install flake8
-      - run: flake8
+
+      - run: python -m pip install pip flake8 black
+      - run: black . --check
+      - run: flake8 --ignore E203,E501,W503 .

--- a/core/templates/github/python/test.yml
+++ b/core/templates/github/python/test.yml
@@ -1,0 +1,28 @@
+name: Test Python
+on:
+  pull_request:
+    paths:
+      - "**.py"
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python <%= it.version %>
+        uses: actions/setup-python@v2
+        with:
+          python-version: <%= it.version %>
+      - name: Install Dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      <%_ if (it.django) { %>
+      - name: Run Tests
+        run: |
+          python manage.py test
+      <% } else { -%>
+      - name: Test with pytest
+        run: |
+          pytest
+      <% } -%>


### PR DESCRIPTION
As described in the issue #23, using as example the GitHub starters CI, add to the Pipelinit the following stacks:
- Docker stack
  - Lint stage
  - Build stage
- Java stack
  - Build stage with Gradle 
- Complement python stack
  - Django and PyTest
  - Black as formatter and flake8 adjusted
- Complement JavaScript stack
  - Add a stage test

To test:
- Check if the unit tests pass 
- Try to generate the Pipelinit CI accordingly to each stack using the sample projects https://github.com/pipelinit/pipelinit-cli/tree/feat/github-starter-stacks#examples


![image](https://user-images.githubusercontent.com/30262244/132575583-6a3be9da-e669-454c-a59b-a4a628c9981f.png)
![image](https://user-images.githubusercontent.com/30262244/132575640-dff5c6c8-138c-4a43-98b7-ff01227cc83b.png)
![image](https://user-images.githubusercontent.com/30262244/132575696-0001bf29-0026-451c-a160-2702a5f60438.png)
![image](https://user-images.githubusercontent.com/30262244/132575864-eab78019-53e0-481f-984d-9ad43e1b24d5.png)

