### PR TITLE
fix: Checks if the project has a declared test command defined

### DIFF
--- a/core/plugins/stack/javascript/mod.test.ts
+++ b/core/plugins/stack/javascript/mod.test.ts
@@ -33,6 +33,12 @@ Deno.test("Plugins > Check eslint and node for javascript project", async () => 
               path: "fake-path",
             };
           }
+          if (glob === "./package.json") {
+            yield {
+              name: "package.json",
+              path: "fake-path",
+            };
+          }
           if (glob === "**/.eslintrc.{js,cjs,yaml,yml,json}") {
             yield {
               name: ".eslintrc.js",
@@ -51,7 +57,12 @@ Deno.test("Plugins > Check eslint and node for javascript project", async () => 
         readJSON: async (path: string): Promise<Record<string, unknown>> => {
           const deps = { stylelint: "1.0.0", eslint: "7.2.2" };
           if (path === "fake-path") {
-            return { devDependencies: deps };
+            return {
+              devDependencies: deps,
+              scripts: {
+                test: "yarn jest",
+              },
+            };
           }
           return {};
         },
@@ -69,5 +80,6 @@ Deno.test("Plugins > Check eslint and node for javascript project", async () => 
       eslint: { name: "eslint", hasIgnoreFile: false },
     },
     formatters: { prettier: { name: "prettier", hasIgnoreFile: false } },
+    testCommand: true,
   });
 });

--- a/core/plugins/stack/javascript/mod.ts
+++ b/core/plugins/stack/javascript/mod.ts
@@ -2,6 +2,7 @@ import { Introspector } from "../../../types.ts";
 import { Formatters, introspect as introspectFormatter } from "./formatters.ts";
 import { introspect as introspectLinter, Linters } from "./linters.ts";
 import { introspect as introspectRuntime, Runtime } from "./runtime.ts";
+import { introspect as introspectTestCommand } from "./test.ts";
 import {
   introspect as introspectPackageManager,
   NodePackageManager,
@@ -34,6 +35,10 @@ export default interface JavaScriptProject {
    * Which formatter the project uses, if any
    */
   formatters: Formatters;
+  /**
+   * Project has a configured test command
+   */
+  testCommand: boolean;
 }
 
 export const introspector: Introspector<JavaScriptProject> = {
@@ -56,6 +61,7 @@ export const introspector: Introspector<JavaScriptProject> = {
         formatters: {
           deno: {},
         },
+        testCommand: false,
       };
     }
 
@@ -68,11 +74,15 @@ export const introspector: Introspector<JavaScriptProject> = {
     const linters = await introspectLinter(context);
     const formatters = await introspectFormatter(context);
 
+    // Has a test script
+    const hasTestCommand = await introspectTestCommand(context);
+
     return {
-      runtime,
-      packageManager,
-      linters,
-      formatters,
+      runtime: runtime,
+      packageManager: packageManager,
+      linters: linters,
+      formatters: formatters,
+      testCommand: hasTestCommand,
     };
   },
 };

--- a/core/plugins/stack/javascript/test.ts
+++ b/core/plugins/stack/javascript/test.ts
@@ -1,0 +1,14 @@
+import { IntrospectFn } from "../../../types.ts";
+
+export const introspect: IntrospectFn<boolean> = async (context) => {
+  for await (const file of context.files.each("./package.json")) {
+    const packageJson = await context.files.readJSON(file.path);
+    if (packageJson?.scripts?.test) {
+      const testCommand = packageJson.scripts.test;
+      if (testCommand) {
+        return true;
+      }
+    }
+  }
+  return false;
+};

--- a/core/templates/github/javascript/test.yaml
+++ b/core/templates/github/javascript/test.yaml
@@ -14,7 +14,7 @@ jobs:
         with:
           deno-version: v1.x
       - run: deno test --unstable --allow-all
-<% } else if (it.runtime.name === "node") { -%>
+<% } else if (it.runtime.name === "node" && it.testCommand) { -%>
 name: Test Node
 on:
   pull_request:


### PR DESCRIPTION
Checks if the project has a declared test command defined

To test:

- Run the unit tests
- Check on repositories with the `test` command on the package.json if the `pipelinit.javascript.test.yaml` **is created**.  
- Check on repositories without the `test` command on the package.json if the `pipelinit.javascript.test.yaml` **is not created**.  

Projects tested:
Without test declared: https://github.com/pipelinit/pipelinit-sample-vue-html
With test declared: https://github.com/pipelinit/action