### PR TITLE
fix: adjust html stack vue identification

### DIFF
--- a/core/plugins/stack/html/frameworks.ts
+++ b/core/plugins/stack/html/frameworks.ts
@@ -1,0 +1,23 @@
+import { IntrospectFn } from "../../../types.ts";
+import { introspect as instrospectVue } from "./vue.ts";
+
+// deno-lint-ignore no-empty-interface
+interface Vue {}
+
+export type Frameworks = {
+  vue?: Vue;
+};
+
+export const introspect: IntrospectFn<Frameworks> = async (context) => {
+  const logger = context.getLogger("html");
+  const frameworks: Frameworks = {};
+  logger.debug("detecting linter");
+
+  const isVue = await instrospectVue(context);
+  if (isVue) {
+    logger.debug("detected Vue.Js");
+    frameworks.vue = {};
+  }
+
+  return frameworks;
+};

--- a/core/plugins/stack/html/mod.test.ts
+++ b/core/plugins/stack/html/mod.test.ts
@@ -3,7 +3,11 @@ import { assertEquals, context, deepMerge } from "../../../tests/mod.ts";
 
 import { introspector } from "./mod.ts";
 
-const fakeContext = () => {
+const fakeContext = (
+  {
+    isVue = false,
+  } = {},
+) => {
   return deepMerge(
     context,
     {
@@ -11,6 +15,9 @@ const fakeContext = () => {
         // deno-lint-ignore require-await
         includes: async (glob: string): Promise<boolean> => {
           if (glob === "**/.eslintrc.{js,cjs,yaml,yml,json}") {
+            return true;
+          }
+          if (glob === "**/*.vue" && isVue) {
             return true;
           }
           return false;
@@ -61,7 +68,7 @@ const fakeContext = () => {
 
 Deno.test("Plugins > Html has stylelint and eslint configured", async () => {
   const result = await introspector.introspect(
-    fakeContext(),
+    fakeContext({ isVue: true }),
   );
 
   assertEquals(result, {
@@ -77,12 +84,13 @@ Deno.test("Plugins > Html has stylelint and eslint configured", async () => {
       styleLint: { name: "stylelint" },
     },
     formatters: { prettier: { name: "prettier", hasIgnoreFile: false } },
+    frameworks: { vue: {} },
   });
 });
 
-Deno.test("Plugins > Html has stylelint and eslint configured", async () => {
+Deno.test("Plugins > Html has stylelint and eslint configured and not Vue", async () => {
   const result = await introspector.introspect(
-    fakeContext(),
+    fakeContext({ isVue: false }),
   );
 
   assertEquals(result, {
@@ -98,6 +106,6 @@ Deno.test("Plugins > Html has stylelint and eslint configured", async () => {
       styleLint: { name: "stylelint" },
     },
     formatters: { prettier: { name: "prettier", hasIgnoreFile: false } },
-    isVue: false,
+    frameworks: {},
   });
 });

--- a/core/plugins/stack/html/mod.test.ts
+++ b/core/plugins/stack/html/mod.test.ts
@@ -98,5 +98,6 @@ Deno.test("Plugins > Html has stylelint and eslint configured", async () => {
       styleLint: { name: "stylelint" },
     },
     formatters: { prettier: { name: "prettier", hasIgnoreFile: false } },
+    isVue: false,
   });
 });

--- a/core/plugins/stack/html/mod.ts
+++ b/core/plugins/stack/html/mod.ts
@@ -1,6 +1,8 @@
 import { Introspector } from "../../../types.ts";
 import { Formatters, introspect as introspectFormatter } from "./formatters.ts";
 import { introspect as introspectLinter, Linters } from "./linters.ts";
+import { introspect as introspectVue } from "./vue.ts";
+
 import {
   introspect as introspectRuntime,
   Runtime,
@@ -37,6 +39,10 @@ export default interface HtmlProject {
    * Which formatter the project uses, if any
    */
   formatters: Formatters;
+  /**
+   * Which formatter the project uses, if any
+   */
+  isVue: boolean;
 }
 
 export const introspector: Introspector<HtmlProject> = {
@@ -59,6 +65,7 @@ export const introspector: Introspector<HtmlProject> = {
         formatters: {
           deno: {},
         },
+        isVue: false,
       };
     }
 
@@ -71,11 +78,15 @@ export const introspector: Introspector<HtmlProject> = {
     logger.debug(`detecting linters for html`);
     const formatters = await introspectFormatter(context);
 
+    // Check if project is vue
+    const isVue = await introspectVue(context);
+
     return {
       runtime,
       packageManager,
       linters,
       formatters,
+      isVue: isVue,
     };
   },
 };

--- a/core/plugins/stack/html/mod.ts
+++ b/core/plugins/stack/html/mod.ts
@@ -1,7 +1,10 @@
 import { Introspector } from "../../../types.ts";
 import { Formatters, introspect as introspectFormatter } from "./formatters.ts";
 import { introspect as introspectLinter, Linters } from "./linters.ts";
-import { introspect as introspectVue } from "./vue.ts";
+import {
+  Frameworks,
+  introspect as introspectFrameworks,
+} from "./frameworks.ts";
 
 import {
   introspect as introspectRuntime,
@@ -40,9 +43,9 @@ export default interface HtmlProject {
    */
   formatters: Formatters;
   /**
-   * Which formatter the project uses, if any
+   * Which framework the project uses, if any
    */
-  isVue: boolean;
+  frameworks: Frameworks;
 }
 
 export const introspector: Introspector<HtmlProject> = {
@@ -65,7 +68,7 @@ export const introspector: Introspector<HtmlProject> = {
         formatters: {
           deno: {},
         },
-        isVue: false,
+        frameworks: {},
       };
     }
 
@@ -78,15 +81,16 @@ export const introspector: Introspector<HtmlProject> = {
     logger.debug(`detecting linters for html`);
     const formatters = await introspectFormatter(context);
 
-    // Check if project is vue
-    const isVue = await introspectVue(context);
+    // Check if project frameworks
+    logger.debug(`detecting web frameworks`);
+    const frameworks = await introspectFrameworks(context);
 
     return {
       runtime,
       packageManager,
       linters,
       formatters,
-      isVue: isVue,
+      frameworks,
     };
   },
 };

--- a/core/plugins/stack/html/vue.ts
+++ b/core/plugins/stack/html/vue.ts
@@ -1,0 +1,6 @@
+import { IntrospectFn } from "../../../types.ts";
+
+export const introspect: IntrospectFn<boolean> = async (context) => {
+  // Search for any .vue file
+  return await context.files.includes("**/*.vue");
+};

--- a/core/plugins/stack/python/frameworks.ts
+++ b/core/plugins/stack/python/frameworks.ts
@@ -1,0 +1,22 @@
+import { IntrospectFn } from "../../../types.ts";
+import { introspect as instrospectDjango } from "./django.ts";
+
+// deno-lint-ignore no-empty-interface
+interface Django {}
+
+export type Frameworks = {
+  django?: Django;
+};
+
+export const introspect: IntrospectFn<Frameworks> = async (context) => {
+  const frameworks: Frameworks = {};
+  const logger = context.getLogger("python");
+
+  const isDjango = await instrospectDjango(context);
+  if (isDjango) {
+    logger.debug("detected Django");
+    frameworks.django = {};
+  }
+
+  return frameworks;
+};

--- a/core/plugins/stack/python/mod.test.ts
+++ b/core/plugins/stack/python/mod.test.ts
@@ -49,7 +49,9 @@ Deno.test("Plugins > Check if python version and django project is identified", 
 
   assertEquals(result, {
     version: "3.6",
-    isDjango: true,
+    frameworks: {
+      django: {},
+    },
   });
 });
 
@@ -60,6 +62,6 @@ Deno.test("Plugins > Check if python version and a non-django-project", async ()
 
   assertEquals(result, {
     version: "3.6",
-    isDjango: false,
+    frameworks: {},
   });
 });

--- a/core/plugins/stack/python/mod.ts
+++ b/core/plugins/stack/python/mod.ts
@@ -1,6 +1,9 @@
 import { Introspector } from "../../../types.ts";
 import { introspect as introspectVersion } from "./version.ts";
-import { introspect as introspectDjango } from "./django.ts";
+import {
+  Frameworks,
+  introspect as introspectFrameworks,
+} from "./frameworks.ts";
 
 /**
  * Introspected information about a project with Python
@@ -11,9 +14,9 @@ export default interface PythonProject {
    */
   version?: string;
   /**
-   * If is a Django project
+   * List of possible project frameworks
    */
-  isDjango?: boolean;
+  frameworks?: Frameworks;
 }
 
 export const introspector: Introspector<PythonProject | undefined> = {
@@ -32,14 +35,16 @@ export const introspector: Introspector<PythonProject | undefined> = {
     }
     logger.debug(`detected version ${version}`);
 
-    // Django
-    const django = await introspectDjango(context);
-    if (django) {
-      logger.debug("detected Django project");
+    // Search python frameworks
+    logger.debug("detecting frameworks");
+    const frameworks = await introspectFrameworks(context);
+    if (frameworks === undefined) {
+      logger.debug("didn't detect any know python framework");
     }
+
     return {
       version: version,
-      isDjango: django,
+      frameworks: frameworks,
     };
   },
 };

--- a/core/templates/github/html/lint.yml
+++ b/core/templates/github/html/lint.yml
@@ -1,4 +1,4 @@
-<% if (it.runtime.name === "node" && it.linters) { -%>
+<% if (it.runtime.name === "node" && it.linters && it.isVue) { -%>
 name: Lint Vue
 on:
   pull_request:

--- a/core/templates/github/html/lint.yml
+++ b/core/templates/github/html/lint.yml
@@ -1,4 +1,4 @@
-<% if (it.runtime.name === "node" && it.linters && it.isVue) { -%>
+<% if (it.runtime.name === "node" && it.linters && it.frameworks.vue) { -%>
 name: Lint Vue
 on:
   pull_request:

--- a/core/templates/github/python/test.yml
+++ b/core/templates/github/python/test.yml
@@ -17,7 +17,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install pytest
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-      <%_ if (it.django) { %>
+      <%_ if (it.frameworks.django) { %>
       - name: Run Tests
         run: |
           python manage.py test


### PR DESCRIPTION
Adds a boolean identifier checking if the project is VUE
for the HTML introspection.

Resolves: https://github.com/pipelinit/pipelinit-cli/issues/36

To test:

- Run the unit tests
- Check if the lint stage for HTML stack **IS NOT GENERATED** in this project https://github.com/renanstn/poll-generator or any project with html files and **no VUE files**