### PR TITLE
feat: add shell stack

### DIFF
--- a/core/plugins/stack/mod.ts
+++ b/core/plugins/stack/mod.ts
@@ -4,6 +4,7 @@ import { introspector as HtmlIntrospector } from "./html/mod.ts";
 import { introspector as JavaIntrospector } from "./java/mod.ts";
 import { introspector as JavaScriptIntrospector } from "./javascript/mod.ts";
 import { introspector as PythonIntrospector } from "./python/mod.ts";
+import { introspector as ShellIntrospector } from "./shell/mod.ts";
 
 import type CSSProject from "./css/mod.ts";
 import type DockerProject from "./docker/mod.ts";
@@ -11,6 +12,7 @@ import type HtmlProject from "./html/mod.ts";
 import type JavaScriptProject from "./javascript/mod.ts";
 import type JavaProject from "./java/mod.ts";
 import type PythonProject from "./python/mod.ts";
+import type ShellProject from "./shell/mod.ts";
 
 // Keep it in alphabetical order
 export type ProjectData =
@@ -19,7 +21,8 @@ export type ProjectData =
   | HtmlProject
   | JavaScriptProject
   | JavaProject
-  | PythonProject;
+  | PythonProject
+  | ShellProject;
 
 export type {
   CSSProject,
@@ -28,6 +31,7 @@ export type {
   JavaProject,
   JavaScriptProject,
   PythonProject,
+  ShellProject,
 };
 
 export const introspectors = [
@@ -37,4 +41,5 @@ export const introspectors = [
   { name: "javascript", ...JavaScriptIntrospector },
   { name: "java", ...JavaIntrospector },
   { name: "python", ...PythonIntrospector },
+  { name: "shell", ...ShellIntrospector },
 ];

--- a/core/plugins/stack/shell/linters.ts
+++ b/core/plugins/stack/shell/linters.ts
@@ -1,0 +1,22 @@
+import { IntrospectFn } from "../../../types.ts";
+import { introspect as introspectShellCheck } from "./shellcheck.ts";
+
+// deno-lint-ignore no-empty-interface
+interface ShellCheck {}
+
+export type Linters = {
+  shellCheck?: ShellCheck;
+};
+
+export const introspect: IntrospectFn<Linters> = async (context) => {
+  const linters: Linters = {};
+  const logger = context.getLogger("shell");
+
+  const hasShellCheck = await introspectShellCheck(context);
+  if (hasShellCheck) {
+    logger.debug("detected ShellCheck");
+    linters.shellCheck = {};
+  }
+
+  return linters;
+};

--- a/core/plugins/stack/shell/mod.test.ts
+++ b/core/plugins/stack/shell/mod.test.ts
@@ -1,0 +1,47 @@
+import { context } from "../../../tests/mod.ts";
+import { assertEquals, deepMerge } from "../../../deps.ts";
+
+import { introspector } from "./mod.ts";
+
+const fakeContext = (
+  {
+    hasShellFiles = false,
+    hasSuggest = false,
+  } = {},
+) => {
+  return deepMerge(
+    context,
+    {
+      suggestDefault: hasSuggest,
+      files: {
+        // deno-lint-ignore require-await
+        includes: async (glob: string): Promise<boolean> => {
+          if (glob === "**/*.{sh,bash}" && hasShellFiles) {
+            return true;
+          }
+          return false;
+        },
+      },
+    },
+  );
+};
+
+Deno.test("Plugins > Test shell stack with a project with no sh or bash files", async () => {
+  const result = await introspector.introspect(
+    fakeContext({ hasShellFiles: false, hasSuggest: false }),
+  );
+
+  assertEquals(result, {
+    linters: {},
+  });
+});
+
+Deno.test("Plugins > Test shell stack", async () => {
+  const result = await introspector.introspect(
+    fakeContext({ hasShellFiles: true, hasSuggest: true }),
+  );
+
+  assertEquals(result, {
+    linters: { shellCheck: {} },
+  });
+});

--- a/core/plugins/stack/shell/mod.ts
+++ b/core/plugins/stack/shell/mod.ts
@@ -1,0 +1,43 @@
+import { Introspector } from "../../../types.ts";
+import { introspect as introspectLinters, Linters } from "./linters.ts";
+
+/**
+ * Introspected information about a project with ShellScript
+ */
+export default interface ShellProject {
+  /**
+   * Which linter the project uses, if any
+   */
+  linters?: Linters;
+}
+
+function anyValue(records: Record<string, unknown>): boolean {
+  return Object.values(records).some((v) => v);
+}
+
+export const introspector: Introspector<ShellProject> = {
+  detect: async (context) => {
+    return await context.files.includes("**/*.{sh,bash}");
+  },
+  introspect: async (context) => {
+    const logger = context.getLogger("shell");
+
+    logger.debug("detecting linters");
+    const linters = await introspectLinters(context);
+
+    if (!anyValue(linters)) {
+      logger.debug("didn't detect any know shell linter");
+
+      if (context.suggestDefault) {
+        logger.warning("Using ShellCheck as the default shell linter ");
+        return {
+          linters: { shellCheck: {} },
+        };
+      }
+    }
+
+    return {
+      linters: linters,
+    };
+  },
+};

--- a/core/plugins/stack/shell/shellcheck.ts
+++ b/core/plugins/stack/shell/shellcheck.ts
@@ -1,0 +1,6 @@
+import { IntrospectFn } from "../../../types.ts";
+
+export const introspect: IntrospectFn<boolean> = async (context) => {
+  // Search for project .shellcheckrc
+  return await context.files.includes("**/.shellcheckrc");
+};

--- a/core/templates/github/shell/lint.yml
+++ b/core/templates/github/shell/lint.yml
@@ -1,0 +1,15 @@
+<% if (it.linters.shellCheck) { -%>
+name: Lint Shell
+on:
+  pull_request:
+    paths:
+      - "**.sh"
+      - "**.bash"
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@master
+<% } -%>


### PR DESCRIPTION
Adds a first implementation of the shell stack
using the ludeeus/action-shellcheck in the template
At first, it only checks .sh and .bash files

Resolves: https://github.com/pipelinit/pipelinit-cli/issues/9

To test:
- Run the unit tests
- Run on a project with sh or bash files changed on a pull request

Example:
https://github.com/pipelinit/pipelinit-sample-python/pull/2/checks?check_run_id=3700192189
https://github.com/pipelinit/pipelinit-sample-python/pull/2/checks?check_run_id=3700097744