### PR TITLE
feat: add lint and build for multiple docker files

### DIFF
--- a/core/plugins/stack/docker/mod.ts
+++ b/core/plugins/stack/docker/mod.ts
@@ -9,7 +9,7 @@ export default interface DockerProject {
 
 export const introspector: Introspector<DockerProject> = {
   detect: async (context) => {
-    return await context.files.includes("./Dockerfile");
+    return await context.files.includes("**/Dockerfile");
   },
   introspect: async (context) => {
     const logger = await context.getLogger("docker");

--- a/core/templates/github/docker/build.yml
+++ b/core/templates/github/docker/build.yml
@@ -1,15 +1,17 @@
-name: Docker Image CI
-
+name: Build Docker
 on:
   pull_request:
     paths:
-      - "Dockerfile"
-
+      - "**Dockerfile"
 jobs:
   build:
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v2
-      - name: Build the Docker image
-        run: docker build . --file Dockerfile --tag image:$(date +%s)
+      - name: Build Dockerfiles
+        run: |
+          for dockerfile in $(git ls-files **/*Dockerfile* Dockerfile); do
+            echo "Starting build for the Dockerfile $dockerfile"
+            docker build . --file $dockerfile
+          done
+        shell: bash

--- a/core/templates/github/docker/build.yml
+++ b/core/templates/github/docker/build.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Build Dockerfiles
         run: |
-          for dockerfile in $(git ls-files **/*Dockerfile* Dockerfile); do
+          for dockerfile in $(find . -iname "*Dockerfile*" -o -iwholename "./Dockerfile"); do
             echo "Starting build for the Dockerfile $dockerfile"
             docker build . --file $dockerfile
           done

--- a/core/templates/github/docker/lint.yml
+++ b/core/templates/github/docker/lint.yml
@@ -6,12 +6,8 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    container: hadolint/hadolint:latest-debian
     steps:
       - uses: actions/checkout@v2
-      - run: |
-          for dockerfile in $(git ls-files **/*Dockerfile* Dockerfile)
-          do
-            echo "Starting lint for the Dockerfile $dockerfile"
-            docker run --rm -i hadolint/hadolint < $dockerfile
-          done
-        shell: bash
+      - name: Run Hadolint on the project
+        run: hadolint $(find . -iname "*Dockerfile*" -o -iwholename "./Dockerfile")

--- a/core/templates/github/docker/lint.yml
+++ b/core/templates/github/docker/lint.yml
@@ -1,16 +1,17 @@
-name: Docker Image CI
-
+name: Docker file Lint
 on:
   pull_request:
     paths:
-      - "Dockerfile"
-
+      - "**Dockerfile"
 jobs:
   lint:
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v2
-      - uses: hadolint/hadolint-action@v1.5.0
-        with:
-          dockerfile: Dockerfile
+      - run: |
+          for dockerfile in $(git ls-files **/*Dockerfile* Dockerfile)
+          do
+            echo "Starting lint for the Dockerfile $dockerfile"
+            docker run --rm -i hadolint/hadolint < $dockerfile
+          done
+        shell: bash


### PR DESCRIPTION
To improve the docker stack uses the git ls-files command, to exclude the git ignore and then loop through the project docker files using the lint and build command in each file.

Resolves: https://github.com/pipelinit/pipelinit-cli/issues/41

To test:
- Run the unit tests
- Test on a project with multiples Dockerfiles
  - Test if the pipeline triggers with changes in any Dockerfile
  - Test if the lint and build stage runs for all Dockerfiles inside the project 

Example runs:
https://github.com/pipelinit/pipelinit-sample-docker/runs/3724322039?check_suite_focus=true
https://github.com/pipelinit/pipelinit-sample-docker/runs/3724293013?check_suite_focus=true