### PR TITLE
Improve python support

### DIFF
--- a/core/plugins/stack/python/black.ts
+++ b/core/plugins/stack/python/black.ts
@@ -1,0 +1,31 @@
+import { IntrospectFn } from "../../../types.ts";
+import { hasPythonDependency } from "./dependencies.ts";
+
+export interface Black {
+  name: "black";
+  isDependency: boolean;
+}
+
+export const introspect: IntrospectFn<Black | null> = async (context) => {
+  const isDependency = await hasPythonDependency(context, "black");
+  let hasBlackConfig = false;
+
+  for await (const file of context.files.each("**/pyproject.toml")) {
+    const pyproject = await context.files.readToml(file.path);
+    hasBlackConfig = pyproject.tool?.black != null;
+  }
+
+  if (hasBlackConfig) {
+    return {
+      name: "black",
+      isDependency: isDependency,
+    };
+  } else if (isDependency) {
+    return {
+      name: "black",
+      isDependency: true,
+    };
+  }
+
+  return null;
+};

--- a/core/plugins/stack/python/dependencies.ts
+++ b/core/plugins/stack/python/dependencies.ts
@@ -1,0 +1,52 @@
+import { Context } from "../../../types.ts";
+
+const readDependencyFile = async (context: Context) => {
+  const dependencies: string[] = [];
+
+  for await (const file of context.files.each("**/pyproject.toml")) {
+    const pyproject = await context.files.readToml(file.path);
+
+    const poetryDeps = pyproject.tool?.poetry?.dependencies;
+    if (poetryDeps) {
+      dependencies.push(...Object.keys(poetryDeps));
+    }
+    const poetryDevDeps = pyproject.tool?.poetry["dev-dependencies"];
+    if (poetryDevDeps) {
+      dependencies.push(...Object.keys(poetryDevDeps));
+    }
+  }
+
+  for await (const file of context.files.each("**/Pipfile")) {
+    const pipfile = await context.files.readToml(file.path);
+
+    const pipFileDeps = pipfile.packages;
+    if (pipFileDeps) {
+      dependencies.push(...Object.keys(pipFileDeps));
+    }
+    const pipFileDevDeps = pipfile["dev-packages"];
+    if (pipFileDevDeps) {
+      dependencies.push(...Object.keys(pipFileDevDeps));
+    }
+  }
+
+  for await (const file of context.files.each("**/requirements.txt")) {
+    const requirements = await context.files.readText(file.path);
+    // Using a modified version of the regex pointed on the PEP 508
+    // The only difference is the matching of the dependency version number was removed
+    // Reference: https://www.python.org/dev/peps/pep-0508/#names
+    const reqDeps = requirements.match(/[A-Z][A-Z_-]*[A-Z0-9]/gmi);
+    if (reqDeps) {
+      dependencies.push(...reqDeps);
+    }
+  }
+
+  return dependencies;
+};
+
+export const hasPythonDependency = async (
+  context: Context,
+  dependencyName: string,
+): Promise<boolean> => {
+  const dependencies = await readDependencyFile(context);
+  return dependencies.some((dep) => dep === dependencyName);
+};

--- a/core/plugins/stack/python/flake8.ts
+++ b/core/plugins/stack/python/flake8.ts
@@ -1,0 +1,30 @@
+import { IntrospectFn } from "../../../types.ts";
+import { hasPythonDependency } from "./dependencies.ts";
+
+export interface Flake8 {
+  name: "flake8";
+  isDependency: boolean;
+}
+
+export const introspect: IntrospectFn<Flake8 | null> = async (context) => {
+  const isDependency = await hasPythonDependency(context, "flake8");
+  // Search for any of the following files:
+  // .flake8
+  const hasFlake8Config = await context.files.includes(
+    "**/.flake8",
+  );
+
+  if (hasFlake8Config) {
+    return {
+      name: "flake8",
+      isDependency: isDependency,
+    };
+  } else if (isDependency) {
+    return {
+      name: "flake8",
+      isDependency: true,
+    };
+  }
+
+  return null;
+};

--- a/core/plugins/stack/python/formatters.ts
+++ b/core/plugins/stack/python/formatters.ts
@@ -1,0 +1,29 @@
+import { IntrospectFn } from "../../../types.ts";
+import { Black, introspect as introspectBlack } from "./black.ts";
+
+export type Formatters = {
+  black?: Black;
+};
+
+export const introspect: IntrospectFn<Formatters> = async (context) => {
+  const formatters: Formatters = {};
+  const logger = context.getLogger("python");
+
+  const blackInfo = await introspectBlack(context);
+  if (blackInfo) {
+    logger.debug("detected Black");
+    formatters.black = blackInfo;
+  } else {
+    if (context.suggestDefault) {
+      logger.warning(
+        "No formatters for python were identified in the project, creating default pipeline with 'black' WITHOUT any specific configuration",
+      );
+      formatters.black = {
+        isDependency: false,
+        name: "black",
+      };
+    }
+  }
+
+  return formatters;
+};

--- a/core/plugins/stack/python/frameworks.ts
+++ b/core/plugins/stack/python/frameworks.ts
@@ -1,5 +1,5 @@
 import { IntrospectFn } from "../../../types.ts";
-import { introspect as instrospectDjango } from "./django.ts";
+import { introspect as introspectDjango } from "./django.ts";
 
 // deno-lint-ignore no-empty-interface
 interface Django {}
@@ -12,7 +12,7 @@ export const introspect: IntrospectFn<Frameworks> = async (context) => {
   const frameworks: Frameworks = {};
   const logger = context.getLogger("python");
 
-  const isDjango = await instrospectDjango(context);
+  const isDjango = await introspectDjango(context);
   if (isDjango) {
     logger.debug("detected Django");
     frameworks.django = {};

--- a/core/plugins/stack/python/linters.ts
+++ b/core/plugins/stack/python/linters.ts
@@ -1,0 +1,29 @@
+import { IntrospectFn } from "../../../types.ts";
+import { Flake8, introspect as introspectFlake8 } from "./flake8.ts";
+
+export type Linters = {
+  flake8?: Flake8;
+};
+
+export const introspect: IntrospectFn<Linters> = async (context) => {
+  const linters: Linters = {};
+  const logger = context.getLogger("python");
+
+  const flake8Info = await introspectFlake8(context);
+  if (flake8Info) {
+    logger.debug("detected Flake8");
+    linters.flake8 = flake8Info;
+  } else {
+    if (context.suggestDefault) {
+      logger.warning(
+        "No linters for python were identified in the project, creating default pipeline with 'flake8' WITHOUT any specific configuration",
+      );
+      linters.flake8 = {
+        isDependency: false,
+        name: "flake8",
+      };
+    }
+  }
+
+  return linters;
+};

--- a/core/plugins/stack/python/mod.test.ts
+++ b/core/plugins/stack/python/mod.test.ts
@@ -7,6 +7,10 @@ import { introspector } from "./mod.ts";
 const fakeContext = (
   {
     isDjango = false,
+    hasPytest = false,
+    isPoetry = false,
+    isPipenv = false,
+    isRequirements = false,
   } = {},
 ) => {
   return deepMerge(
@@ -21,12 +25,39 @@ const fakeContext = (
           if (glob === "**/manage.py" && isDjango) {
             return true;
           }
+          if (glob === "**/poetry.lock" && isPoetry) {
+            return true;
+          }
+          if (glob === "**/Pipfile.lock" && isPipenv) {
+            return true;
+          }
+          if (glob === "**/requirements.txt" && isRequirements) {
+            return true;
+          }
           return false;
         },
         each: async function* (glob: string): AsyncIterableIterator<FileEntry> {
-          if (glob === "**/Pipfile") {
+          if (glob === "**/.python-version") {
             yield {
-              name: "Pipefile",
+              name: ".python-version",
+              path: "fake-path-root",
+            };
+          }
+          if (glob === "**/Pipfile" && isPipenv) {
+            yield {
+              name: "Pipfile",
+              path: "fake-path",
+            };
+          }
+          if (glob === "**/pyproject.toml" && isPoetry) {
+            yield {
+              name: "pyproject.toml",
+              path: "fake-path",
+            };
+          }
+          if (glob === "**/requirements.txt" && isRequirements) {
+            yield {
+              name: "requirements.txt",
               path: "fake-path",
             };
           }
@@ -35,33 +66,262 @@ const fakeContext = (
         // deno-lint-ignore require-await
         readToml: async (path: string): Promise<Record<string, unknown>> => {
           if (path === "fake-path") {
-            return { requires: { python_version: "3.6" } };
+            if (isPipenv) {
+              const dep = {
+                requires: { python_version: "3.6" },
+                packages: {},
+                "dev-packages": {},
+              };
+              if (isDjango) {
+                dep.packages = { django: "2.0.9" };
+              }
+              if (hasPytest) {
+                dep["dev-packages"] = { pytest: "2" };
+              }
+              return dep;
+            }
+            if (isPoetry) {
+              const dep = {
+                tool: {
+                  poetry: {
+                    dependencies: {},
+                    "dev-packages": {},
+                  },
+                },
+              };
+              if (isDjango) {
+                dep.tool.poetry.dependencies = { django: "2.0.9" };
+              }
+              if (hasPytest) {
+                dep.tool.poetry["dev-packages"] = { pytest: "2" };
+              }
+              return dep;
+            }
           }
+
           return {};
+        },
+        // deno-lint-ignore require-await
+        readText: async (path: string) => {
+          if (path === "fake-path-root") {
+            return "3.6";
+          }
+          if (path === "fake-path") {
+            if (isRequirements) {
+              let dep = "dep == 0.1.0";
+              if (isDjango) {
+                dep += "\ndjango == 2.0.9";
+              }
+              if (hasPytest) {
+                dep += "\npytest == 2";
+              }
+              return dep;
+            }
+          }
+          return "";
         },
       },
     },
   );
 };
 
-Deno.test("Plugins > Check if python version and django project is identified", async () => {
-  const result = await introspector.introspect(fakeContext({ isDjango: true }));
-
-  assertEquals(result, {
-    version: "3.6",
-    frameworks: {
-      django: {},
-    },
-  });
-});
-
-Deno.test("Plugins > Check if python version and a non-django-project", async () => {
+Deno.test("Plugins > Check if python version and django project is identified PIPENV", async () => {
   const result = await introspector.introspect(
-    fakeContext({ isDjango: false }),
+    fakeContext({
+      isDjango: true,
+      isPipenv: true,
+    }),
   );
 
   assertEquals(result, {
     version: "3.6",
+    formatters: {
+      black: {
+        isDependency: false,
+        name: "black",
+      },
+    },
+    frameworks: {
+      django: {},
+    },
+    hasPytest: false,
+    linters: {
+      flake8: {
+        isDependency: false,
+        name: "flake8",
+      },
+    },
+    packageManager: {
+      name: "pipenv",
+      commands: {
+        install: "python -m pip install pipenv; pipenv install --dev",
+        run: "pipenv run",
+      },
+    },
+  });
+});
+
+Deno.test("Plugins > Check if python version and a non-django-project PIPENV", async () => {
+  const result = await introspector.introspect(
+    fakeContext({ isDjango: false, isPipenv: true }),
+  );
+
+  assertEquals(result, {
+    version: "3.6",
+    formatters: {
+      black: {
+        isDependency: false,
+        name: "black",
+      },
+    },
     frameworks: {},
+    hasPytest: false,
+    linters: {
+      flake8: {
+        isDependency: false,
+        name: "flake8",
+      },
+    },
+    packageManager: {
+      name: "pipenv",
+      commands: {
+        install: "python -m pip install pipenv; pipenv install --dev",
+        run: "pipenv run",
+      },
+    },
+  });
+});
+
+Deno.test("Plugins > Check if python version and django project is identified POETRY", async () => {
+  const result = await introspector.introspect(
+    fakeContext({
+      isDjango: true,
+      isPoetry: true,
+    }),
+  );
+
+  assertEquals(result, {
+    version: "3.6",
+    formatters: {
+      black: {
+        isDependency: false,
+        name: "black",
+      },
+    },
+    frameworks: {
+      django: {},
+    },
+    hasPytest: false,
+    linters: {
+      flake8: {
+        isDependency: false,
+        name: "flake8",
+      },
+    },
+    packageManager: {
+      name: "poetry",
+      commands: {
+        install: "python -m pip install poetry; poetry install",
+        run: "poetry run",
+      },
+    },
+  });
+});
+
+Deno.test("Plugins > Check if python version and a non-django-project POETRY", async () => {
+  const result = await introspector.introspect(
+    fakeContext({ isDjango: false, isPoetry: true }),
+  );
+
+  assertEquals(result, {
+    version: "3.6",
+    formatters: {
+      black: {
+        isDependency: false,
+        name: "black",
+      },
+    },
+    frameworks: {},
+    hasPytest: false,
+    linters: {
+      flake8: {
+        isDependency: false,
+        name: "flake8",
+      },
+    },
+    packageManager: {
+      name: "poetry",
+      commands: {
+        install: "python -m pip install poetry; poetry install",
+        run: "poetry run",
+      },
+    },
+  });
+});
+
+Deno.test("Plugins > Check if python version and django project is identified REQ", async () => {
+  const result = await introspector.introspect(
+    fakeContext({
+      isDjango: true,
+      isRequirements: true,
+    }),
+  );
+
+  assertEquals(result, {
+    version: "3.6",
+    formatters: {
+      black: {
+        isDependency: false,
+        name: "black",
+      },
+    },
+    frameworks: {
+      django: {},
+    },
+    hasPytest: false,
+    linters: {
+      flake8: {
+        isDependency: false,
+        name: "flake8",
+      },
+    },
+    packageManager: {
+      name: "pip",
+      commands: {
+        install: "pip install -r requirements.txt",
+        run: "",
+      },
+    },
+  });
+});
+
+Deno.test("Plugins > Check if python version and a non-django-project REQ", async () => {
+  const result = await introspector.introspect(
+    fakeContext({ isDjango: false, isRequirements: true }),
+  );
+
+  assertEquals(result, {
+    version: "3.6",
+    formatters: {
+      black: {
+        isDependency: false,
+        name: "black",
+      },
+    },
+    frameworks: {},
+    hasPytest: false,
+    linters: {
+      flake8: {
+        isDependency: false,
+        name: "flake8",
+      },
+    },
+    packageManager: {
+      name: "pip",
+      commands: {
+        install: "pip install -r requirements.txt",
+        run: "",
+      },
+    },
   });
 });

--- a/core/plugins/stack/python/packageManager.ts
+++ b/core/plugins/stack/python/packageManager.ts
@@ -1,0 +1,62 @@
+import { IntrospectFn } from "../../../types.ts";
+
+interface Pip {
+  name: "pip";
+  commands: {
+    install: "pip install -r requirements.txt";
+    run: "";
+  };
+}
+interface Poetry {
+  name: "poetry";
+  commands: {
+    install: "python -m pip install poetry; poetry install";
+    run: "poetry run";
+  };
+}
+interface Pipenv {
+  name: "pipenv";
+  commands: {
+    install: "python -m pip install pipenv; pipenv install --dev";
+    run: "pipenv run";
+  };
+}
+
+export type PackageManager = Pip | Poetry | Pipenv | undefined;
+
+export const introspect: IntrospectFn<PackageManager> = async (context) => {
+  const logger = context.getLogger("python");
+
+  if (await context.files.includes("**/poetry.lock")) {
+    logger.debug("detected Poetry");
+    return <Poetry> {
+      name: "poetry",
+      commands: {
+        install: "python -m pip install poetry; poetry install",
+        run: "poetry run",
+      },
+    };
+  }
+
+  if (await context.files.includes("**/Pipfile.lock")) {
+    logger.debug("detected Pipenv");
+    return <Pipenv> {
+      name: "pipenv",
+      commands: {
+        install: "python -m pip install pipenv; pipenv install --dev",
+        run: "pipenv run",
+      },
+    };
+  }
+
+  if (await context.files.includes("**/requirements.txt")) {
+    logger.debug("detected Pip");
+    return <Pip> {
+      name: "pip",
+      commands: {
+        install: "pip install -r requirements.txt",
+        run: "",
+      },
+    };
+  }
+};

--- a/core/plugins/stack/python/pytest.ts
+++ b/core/plugins/stack/python/pytest.ts
@@ -2,6 +2,6 @@ import { IntrospectFn } from "../../../types.ts";
 import { hasPythonDependency } from "./dependencies.ts";
 
 export const introspect: IntrospectFn<boolean> = async (context) => {
-  // Search for the Django dependency to define as a Django project
-  return await hasPythonDependency(context, "django");
+  // Search for the Pytest dependency
+  return await hasPythonDependency(context, "pytest");
 };

--- a/core/templates/github/python/lint.yaml
+++ b/core/templates/github/python/lint.yaml
@@ -1,3 +1,4 @@
+<% if (it.linters || it.formatters) { -%>
 name: Lint Python
 on:
   pull_request:
@@ -12,9 +13,24 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: <%= it.version %>
+<% if (it.packageManager) { -%>
+      - run: <%= it.packageManager.commands.install %>
+<% } -%>
 
-      - run: python -m pip install pip flake8 black
-      - run: black . --check
+<% if (!it.formatters.black.isDependency) { -%>
+      - run: python -m pip install pip black
+<% } -%>
+<% if (!it.linters.flake8.isDependency) { -%>
+      - run: python -m pip install pip flake8
+<% } -%>
+
+<% if (it.formatters.black) { -%>
+      - run: <%= it.packageManager.commands.run %> black . --check
+<% } -%>
+<% if (it.linters.flake8) { -%>
       # Adapts Flake8 to run with the Black formatter, using the '--ignore' flag to skip incompatibilities errors
       # Reference: https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html?highlight=other%20tools#id1
-      - run: flake8 --ignore E203,E501,W503 .
+      - run: <%= it.packageManager.commands.run %> flake8 --ignore E203,E501,W503 .
+<% } -%>
+
+<% } -%>

--- a/core/templates/github/python/test.yml
+++ b/core/templates/github/python/test.yml
@@ -1,3 +1,4 @@
+<% if (it.frameworks.django || it.hasPytest) { -%>
 name: Test Python
 on:
   pull_request:
@@ -12,17 +13,17 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: <%= it.version %>
-      - name: Install Dependencies
+<% if (it.packageManager) { -%>
+      - run: <%= it.packageManager.commands.install %>
+<% } -%>
+<% if (it.hasPytest) { -%>
+      - name: Pytest run
         run: |
-          python -m pip install --upgrade pip
-          pip install pytest
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-      <%_ if (it.frameworks.django) { %>
+          pytest
+<% } -%>
+<%_ if (it.frameworks.django) { %>
       - name: Run Tests
         run: |
           python manage.py test
-      <% } else { -%>
-      - name: Test with pytest
-        run: |
-          pytest
-      <% } -%>
+<% } -%>
+<% } -%>


### PR DESCRIPTION
Following the roadmap for the product with this PR we start expanding our python stack capabilities first adding the
following  package managers: 
- Pipenv
- Poetry 
- Requirements file

With this change now is possible to detect what dependency the project already has, thus making more easy to build an accurate template with the correct version of the lint and test dependencies and from this change was possible
to update the lint and format template that now verify if the project already has a linter configuration and installs it accordingly.

Resolves: https://github.com/pipelinit/pipelinit-cli/issues/53
Resolves: https://github.com/pipelinit/pipelinit-cli/issues/48
Resolves: https://github.com/pipelinit/pipelinit-cli/issues/50

To test:

- Run the unit test
- Test Pipelinit Lint and Format stage for Python with the correspondent package manager:
  - Poetry
  - Pipenv
  - Pip wiith requirements file

Examples:
- Testing lint and format with Pipenv
  - Already on project: https://github.com/pipelinit/pipelinit-sample-python/runs/3794528942?check_suite_focus=true
  - As a default recommendation: https://github.com/pipelinit/pipelinit-sample-python/runs/3794464718?check_suite_focus=true

- Testing lint and format with Requirements file
  - Already on project: https://github.com/pipelinit/pipelinit-sample-python/runs/3794572343?check_suite_focus=true
  - As a default recommendation: https://github.com/pipelinit/pipelinit-sample-python/runs/3794590974?check_suite_focus=true

- Testing lint and black with Poetry
  - Already on project: https://github.com/pipelinit/pipelinit-sample-python/pull/2/checks?check_run_id=3794918373
  - As a default recommendation: https://github.com/pipelinit/pipelinit-sample-python/pull/2/checks?check_run_id=3794937050
