### PR TITLE
Add support for isort

### DIFF
--- a/core/plugins/stack/python/formatters.ts
+++ b/core/plugins/stack/python/formatters.ts
@@ -1,15 +1,19 @@
 import { IntrospectFn } from "../../../types.ts";
 import { Black, introspect as introspectBlack } from "./black.ts";
+import { introspect as introspectISort, ISort } from "./isort.ts";
 
 export type Formatters = {
   black?: Black;
+  isort?: ISort;
 };
 
 export const introspect: IntrospectFn<Formatters> = async (context) => {
   const formatters: Formatters = {};
   const logger = context.getLogger("python");
 
+  const iSortInfo = await introspectISort(context);
   const blackInfo = await introspectBlack(context);
+
   if (blackInfo) {
     logger.debug("detected Black");
     formatters.black = blackInfo;
@@ -21,6 +25,21 @@ export const introspect: IntrospectFn<Formatters> = async (context) => {
       formatters.black = {
         isDependency: false,
         name: "black",
+      };
+    }
+  }
+
+  if (iSortInfo) {
+    logger.debug("detected iSort");
+    formatters.isort = iSortInfo;
+  } else {
+    if (context.suggestDefault) {
+      logger.warning(
+        "No formatters for python were identified in the project, creating default pipeline with 'isort' WITHOUT any specific configuration",
+      );
+      formatters.isort = {
+        isDependency: false,
+        name: "isort",
       };
     }
   }

--- a/core/plugins/stack/python/isort.ts
+++ b/core/plugins/stack/python/isort.ts
@@ -1,0 +1,37 @@
+import { IntrospectFn } from "../../../types.ts";
+import { hasPythonDependency } from "./dependencies.ts";
+
+export interface ISort {
+  name: "isort";
+  isDependency: boolean;
+}
+
+export const introspect: IntrospectFn<ISort | null> = async (context) => {
+  const isDependency = await hasPythonDependency(context, "isort");
+  let hasISortConfig = false;
+
+  for await (const file of context.files.each("**/pyproject.toml")) {
+    const pyproject = await context.files.readToml(file.path);
+    hasISortConfig = pyproject.tool?.isort != null;
+  }
+
+  if (!hasISortConfig) {
+    hasISortConfig = await context.files.includes(
+      "**/isort.cfg",
+    );
+  }
+
+  if (hasISortConfig) {
+    return {
+      name: "isort",
+      isDependency: isDependency,
+    };
+  } else if (isDependency) {
+    return {
+      name: "isort",
+      isDependency: true,
+    };
+  }
+
+  return null;
+};

--- a/core/plugins/stack/python/mod.test.ts
+++ b/core/plugins/stack/python/mod.test.ts
@@ -140,6 +140,10 @@ Deno.test("Plugins > Check if python version and django project is identified PI
         isDependency: false,
         name: "black",
       },
+      isort: {
+        isDependency: false,
+        name: "isort",
+      },
     },
     frameworks: {
       django: {},
@@ -172,6 +176,10 @@ Deno.test("Plugins > Check if python version and a non-django-project PIPENV", a
       black: {
         isDependency: false,
         name: "black",
+      },
+      isort: {
+        isDependency: false,
+        name: "isort",
       },
     },
     frameworks: {},
@@ -207,6 +215,10 @@ Deno.test("Plugins > Check if python version and django project is identified PO
         isDependency: false,
         name: "black",
       },
+      isort: {
+        isDependency: false,
+        name: "isort",
+      },
     },
     frameworks: {
       django: {},
@@ -239,6 +251,10 @@ Deno.test("Plugins > Check if python version and a non-django-project POETRY", a
       black: {
         isDependency: false,
         name: "black",
+      },
+      isort: {
+        isDependency: false,
+        name: "isort",
       },
     },
     frameworks: {},
@@ -274,6 +290,10 @@ Deno.test("Plugins > Check if python version and django project is identified RE
         isDependency: false,
         name: "black",
       },
+      isort: {
+        isDependency: false,
+        name: "isort",
+      },
     },
     frameworks: {
       django: {},
@@ -306,6 +326,10 @@ Deno.test("Plugins > Check if python version and a non-django-project REQ", asyn
       black: {
         isDependency: false,
         name: "black",
+      },
+      isort: {
+        isDependency: false,
+        name: "isort",
       },
     },
     frameworks: {},

--- a/core/templates/github/python/lint.yaml
+++ b/core/templates/github/python/lint.yaml
@@ -17,6 +17,9 @@ jobs:
       - run: <%= it.packageManager.commands.install %>
 <% } -%>
 
+<% if (!it.formatters.isort.isDependency) { -%>
+      - run: python -m pip install pip isort
+<% } -%>
 <% if (!it.formatters.black.isDependency) { -%>
       - run: python -m pip install pip black
 <% } -%>
@@ -26,6 +29,9 @@ jobs:
 
 <% if (it.formatters.black) { -%>
       - run: <%= it.packageManager.commands.run %> black . --check
+<% } -%>
+<% if (it.formatters.isort) { -%>
+      - run: <%= it.packageManager.commands.run %> isort . -c
 <% } -%>
 <% if (it.linters.flake8) { -%>
       # Adapts Flake8 to run with the Black formatter, using the '--ignore' flag to skip incompatibilities errors


### PR DESCRIPTION
Adds a first implementation of the `isort` formatter
for the python stack and sets it in the default formatters along with `black`

Resolves: https://github.com/pipelinit/pipelinit-cli/issues/47

To test:
- Run the unit tests
- Test in any python project

Example runs:
- With dependency: https://github.com/pipelinit/pipelinit-sample-python/pull/2/checks?check_run_id=3806362825
- As default recommendation: https://github.com/pipelinit/pipelinit-sample-python/runs/3806321040?check_suite_focus=true