### PR TITLE
Show proper error when every stack fails

### DIFF
--- a/cli/src/commands/default.ts
+++ b/cli/src/commands/default.ts
@@ -1,5 +1,6 @@
 import { ensureFile, platformWriters } from "../../deps.ts";
 import {
+  anyError,
   config,
   context,
   introspect,
@@ -26,28 +27,56 @@ start a discussion proposing the new stack here:
 https://github.com/pipelinit/pipelinit-cli/discussions/new
 `;
 
-export default async function (opts: DefaultOptions): Promise<void> {
-  await prelude(opts);
+/**
+ * Handles the case when no pipeline could be generated.
+ * If there are any errors, that means every detected stack had one (or more)
+ * error(s) that prevented the pipeline generation. Otherwise, no stack was
+ * recognized.
+ */
+function handleEmptyPipeline(): never {
   const logger = context.getLogger("main");
-  const detected = await introspect();
-
-  if (Object.keys(detected).length === 0) {
+  if (anyError()) {
+    outputErrors();
+    Deno.exit(errorCodes.ALL_STACKS_WITH_ERRORS);
+  } else {
     logger.error(WARN_NOTHING_DETECTED);
     Deno.exit(errorCodes.NO_STACK_DETECTED);
   }
+}
 
+type UnPromisify<T> = T extends Promise<infer U> ? U : T;
+type Stack = UnPromisify<ReturnType<typeof introspect>>;
+
+/**
+ * Renders and writes each CI configuration file with the project introspected
+ * data
+ */
+async function outputPipeline(detected: Stack) {
+  const logger = context.getLogger("main");
   const platforms = config.platforms!;
-  for (const platform of platforms) {
-    const files = await platformWriters[platform](
-      context,
-      renderTemplates(platform, detected),
-    );
-    for (const { path, content } of files) {
+  await Promise.all(platforms.map(async (platform) => {
+    const platformWriter = platformWriters[platform];
+    const renderIterator = renderTemplates(platform, detected);
+    const files = await platformWriter(context, renderIterator);
+    await Promise.all(files.map(async ({ path, content }) => {
       logger.info(`Writing ${path}`);
       await ensureFile(path);
       await Deno.writeTextFile(path, content);
-    }
-  }
+    }));
+  }));
+}
 
-  outputErrors();
+/**
+ * The default Pipelinit CLI command detects a project Stack and write
+ * CI pipeline configuration files for the selected CI platform.
+ */
+export default async function (opts: DefaultOptions): Promise<void> {
+  await prelude(opts);
+  const detected = await introspect();
+  if (Object.keys(detected).length === 0) {
+    handleEmptyPipeline();
+  } else {
+    await outputPipeline(detected);
+    outputErrors();
+  }
 }

--- a/cli/src/errors.ts
+++ b/cli/src/errors.ts
@@ -6,4 +6,9 @@ export const errorCodes = {
    * 2 = Pipelinit ran without issues, but couldn't find any known stack
    */
   NO_STACK_DETECTED: 2,
+  /**
+   * 3 = Pipelinit detected at least one stack, but couldn't generate a
+   * pipeline for it.
+   */
+  ALL_STACKS_WITH_ERRORS: 3,
 };

--- a/cli/src/lib/context/errors.ts
+++ b/cli/src/lib/context/errors.ts
@@ -12,13 +12,19 @@ export const errors = {
   },
 };
 
+export const anyError = () => {
+  return errors.list.length > 0;
+};
+
 export const outputErrors = () => {
   if (errors.list.length === 0) return;
   const logger = log.getLogger("main");
-  logger.warning(`Didn't generate pipeline for every detected stack!
-  `);
+  logger.warning("Didn't generate pipeline for every detected stack!");
   for (const error of errors.list) {
     logger.critical(error.title);
     logger.error(error.message);
   }
+  logger.warning(
+    "If you don't want to change your project now, try again with the --no-strict flag.",
+  );
 };

--- a/cli/src/lib/context/mod.ts
+++ b/cli/src/lib/context/mod.ts
@@ -8,8 +8,8 @@ import {
   readText,
   readToml,
 } from "./files.ts";
-import { errors, outputErrors } from "./errors.ts";
-export { outputErrors };
+import { errors } from "./errors.ts";
+export { anyError, outputErrors } from "./errors.ts";
 
 export const context: Context = {
   getLogger: log.getLogger,

--- a/cli/tests/default_test.ts
+++ b/cli/tests/default_test.ts
@@ -23,6 +23,27 @@ test(
 );
 
 test(
+  { fixture: "python/requirements-unknown-version", args: [] },
+  async (proc) => {
+    const [stdout, _stderr, { code }] = await output(proc);
+    assertStringIncludes(stdout, "Detected stack: python");
+    assertStringIncludes(
+      stdout,
+      "Didn't generate pipeline for every detected stack!",
+    );
+    assertStringIncludes(
+      stdout,
+      "Couldn't detect which Python version this project uses.",
+    );
+    assertStringIncludes(
+      stdout,
+      "If you don't want to change your project now, try again with the --no-strict flag.",
+    );
+    assertEquals(code, 3);
+  },
+);
+
+test(
   { fixture: "python/requirements-unknown-version", args: ["--no-strict"] },
   async (proc) => {
     const [stdout, _stderr, { code }] = await output(proc);


### PR DESCRIPTION
If no pipeline was generated, the CLI would always output the error message for no stacks detected, but it's possible to detect one (or more) stacks and don't generate anything because of errors in the introspection phase.

Before this PR, this was possible:
```
Loading project configuration
Detecting stack...
Detected stack: python

Check the available stacks at the project README:
https://github.com/pipelinit/pipelinit-cli#support-overview

(...)
```

Now it correctly shows:
```
Loading project configuration
Detecting stack...
Detected stack: python
Didn't generate pipeline for every detected stack!
Couldn't detect which Python version this project uses.

To fix this issue, consider one of the following suggestions:

(...)

If you don't want to change your project now, try again with the '--no-strict' flag.
```