### PR TITLE
Quote version used in YAML

### DIFF
--- a/cli/tests/fixtures/python/requirements-unknown-version/expected/.github/workflows/pipelinit.python.format.yaml
+++ b/cli/tests/fixtures/python/requirements-unknown-version/expected/.github/workflows/pipelinit.python.format.yaml
@@ -13,12 +13,11 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.10
+          python-version: "3.10"
       - run: pip install -r requirements.txt
 
       - run: python -m pip install pip isort
       - run: python -m pip install pip black
 
-      - run:  black . --check
-      - run:  isort . -c
-
+      - run: black . --check
+      - run: isort . -c

--- a/cli/tests/fixtures/python/requirements-unknown-version/expected/.github/workflows/pipelinit.python.lint.yaml
+++ b/cli/tests/fixtures/python/requirements-unknown-version/expected/.github/workflows/pipelinit.python.lint.yaml
@@ -13,12 +13,11 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.10
+          python-version: "3.10"
       - run: pip install -r requirements.txt
 
       - run: python -m pip install pip flake8
 
       # Adapts Flake8 to run with the Black formatter, using the '--ignore' flag to skip incompatibilities errors
       # Reference: https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html?highlight=other%20tools#id1
-      - run:  flake8 --ignore E203,E501,W503 .
-
+      - run: flake8 --ignore E203,E501,W503 .

--- a/core/templates/github/python/format.yaml
+++ b/core/templates/github/python/format.yaml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: <%= it.version %>
+          python-version: "<%= it.version %>"
 <% if (it.packageManager) { -%>
       - run: <%= it.packageManager.commands.install %>
 <% } -%>
@@ -25,10 +25,10 @@ jobs:
 <% } -%>
 
 <% if (it.formatters.black) { -%>
-      - run: <%= it.packageManager.commands.run %> black . --check
+      - run: <%= it.packageManager.commands.run _%> black . --check
 <% } -%>
 <% if (it.formatters.isort) { -%>
-      - run: <%= it.packageManager.commands.run %> isort . -c
+      - run: <%= it.packageManager.commands.run _%> isort . -c
 <% } -%>
 
-<% } -%>
+<%- } -%>

--- a/core/templates/github/python/lint.yaml
+++ b/core/templates/github/python/lint.yaml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: <%= it.version %>
+          python-version: "<%= it.version %>"
 <% if (it.packageManager) { -%>
       - run: <%= it.packageManager.commands.install %>
 <% } -%>
@@ -24,7 +24,7 @@ jobs:
 <% if (it.linters.flake8) { -%>
       # Adapts Flake8 to run with the Black formatter, using the '--ignore' flag to skip incompatibilities errors
       # Reference: https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html?highlight=other%20tools#id1
-      - run: <%= it.packageManager.commands.run %> flake8 --ignore E203,E501,W503 .
+      - run: <%= it.packageManager.commands.run _%> flake8 --ignore E203,E501,W503 .
 <% } -%>
 
-<% } -%>
+<%- } -%>

--- a/core/templates/github/python/test.yml
+++ b/core/templates/github/python/test.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up Python <%= it.version %>
         uses: actions/setup-python@v2
         with:
-          python-version: <%= it.version %>
+          python-version: "<%= it.version %>"
 <% if (it.packageManager) { -%>
       - run: <%= it.packageManager.commands.install %>
 <% } -%>


### PR DESCRIPTION
Using a semantic version without quotes in the CI YAML files isn't correct. Since YAML supports floating point numbers, a version like 3.10 could be interpreted as 3.1; 3.10 and any other version with a minor or patch with double digits are ok. 

Semantic version values are strings, not numbers.

Check this at the YAML playground:
https://play.yaml.io/main/javascript?input=d3Jvbmc6IDMuMTAKZmluZTogIjMuMTAi

![image](https://user-images.githubusercontent.com/1153190/137783500-67b24e90-dba4-4729-b873-7f5577519117.png)

---

See https://github.com/actions/setup-python/issues/160

