### PR TITLE
Fix javascript lint template and python dependencies search

### DIFF
--- a/core/plugins/stack/python/dependencies.ts
+++ b/core/plugins/stack/python/dependencies.ts
@@ -3,7 +3,7 @@ import { Context } from "../../../types.ts";
 const readDependencyFile = async (context: Context) => {
   const dependencies: string[] = [];
 
-  for await (const file of context.files.each("**/pyproject.toml")) {
+  for await (const file of context.files.each("./pyproject.toml")) {
     const pyproject = await context.files.readToml(file.path);
 
     const poetryDeps = pyproject.tool?.poetry?.dependencies;
@@ -16,7 +16,7 @@ const readDependencyFile = async (context: Context) => {
     }
   }
 
-  for await (const file of context.files.each("**/Pipfile")) {
+  for await (const file of context.files.each("./Pipfile")) {
     const pipfile = await context.files.readToml(file.path);
 
     const pipFileDeps = pipfile.packages;
@@ -29,7 +29,7 @@ const readDependencyFile = async (context: Context) => {
     }
   }
 
-  for await (const file of context.files.each("**/requirements.txt")) {
+  for await (const file of context.files.each("./requirements.txt")) {
     const requirements = await context.files.readText(file.path);
     // Using a modified version of the regex pointed on the PEP 508
     // The only difference is the matching of the dependency version number was removed

--- a/core/plugins/stack/python/mod.test.ts
+++ b/core/plugins/stack/python/mod.test.ts
@@ -25,13 +25,13 @@ const fakeContext = (
           if (glob === "**/manage.py" && isDjango) {
             return true;
           }
-          if (glob === "**/poetry.lock" && isPoetry) {
+          if (glob === "./poetry.lock" && isPoetry) {
             return true;
           }
-          if (glob === "**/Pipfile.lock" && isPipenv) {
+          if (glob === "./Pipfile.lock" && isPipenv) {
             return true;
           }
-          if (glob === "**/requirements.txt" && isRequirements) {
+          if (glob === "./requirements.txt" && isRequirements) {
             return true;
           }
           return false;
@@ -43,19 +43,19 @@ const fakeContext = (
               path: "fake-path-root",
             };
           }
-          if (glob === "**/Pipfile" && isPipenv) {
+          if (glob === "./Pipfile" && isPipenv) {
             yield {
               name: "Pipfile",
               path: "fake-path",
             };
           }
-          if (glob === "**/pyproject.toml" && isPoetry) {
+          if (glob === "./pyproject.toml" && isPoetry) {
             yield {
               name: "pyproject.toml",
               path: "fake-path",
             };
           }
-          if (glob === "**/requirements.txt" && isRequirements) {
+          if (glob === "./requirements.txt" && isRequirements) {
             yield {
               name: "requirements.txt",
               path: "fake-path",

--- a/core/plugins/stack/python/packageManager.ts
+++ b/core/plugins/stack/python/packageManager.ts
@@ -21,7 +21,7 @@ export type PackageManager = {
  * Detects if a project uses [Poetry](https://python-poetry.org/)
  */
 const poetry: IntrospectFn<PackageManager> = async (context) => {
-  if (await context.files.includes("**/poetry.lock")) {
+  if (await context.files.includes("./poetry.lock")) {
     return {
       name: "poetry",
       commands: {
@@ -37,7 +37,7 @@ const poetry: IntrospectFn<PackageManager> = async (context) => {
  * Detects if a project uses [Pipenv](pipenv.pypa.io)
  */
 const pipenv: IntrospectFn<PackageManager> = async (context) => {
-  if (await context.files.includes("**/Pipfile.lock")) {
+  if (await context.files.includes("./Pipfile.lock")) {
     return {
       name: "pipenv",
       commands: {
@@ -60,7 +60,7 @@ const pipenv: IntrospectFn<PackageManager> = async (context) => {
  * https://pip.pypa.io/en/stable/reference/requirements-file-format/#requirements-file-format
  */
 const requirements: IntrospectFn<PackageManager> = async (context) => {
-  if (await context.files.includes("**/requirements.txt")) {
+  if (await context.files.includes("./requirements.txt")) {
     return {
       name: "pip",
       commands: {

--- a/core/templates/github/javascript/lint.yaml
+++ b/core/templates/github/javascript/lint.yaml
@@ -36,23 +36,22 @@ jobs:
       <% } -%>
 <% } -%>
 <% if (it.hasTypeScriptFiles) { -%>
-
   tsc:
-    name: Typecheck Typescript 
+    name: Typecheck Typescript
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-  <% if (it.runtime.name === "deno") { -%>
-    - uses: denoland/setup-deno@v1
-      with:
-        deno-version: v1.x
-    - run: deno cache --unstable $(find . -iname "*.ts")
-  <% } else if (it.runtime.name === "node") { -%>
-   - uses: actions/setup-node@v2
-      with:
-        node-version: '<%= it.runtime.version %>'
+      - uses: actions/checkout@v2
+<% if (it.runtime.name === "deno") { -%>
+      - uses: denoland/setup-deno@v1
+        with:
+          deno-version: v1.x
+      - run: deno cache --unstable $(find . -iname "*.ts")
+<% } else if (it.runtime.name === "node") { -%>
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '<%= it.runtime.version %>'
         cache: '<%= it.packageManager.name %>'
-    - run: <%= it.packageManager.commands.install %>
-    - run: NPM_CONFIG_YES=true npx -p typescript -c 'tsc --init && tsc --noEmit'
-  <% } -%>
+      - run: <%= it.packageManager.commands.install %>
+      - run: NPM_CONFIG_YES=true npx -p typescript -c 'tsc --init && tsc --noEmit'
+<% } -%>
 <% } -%>


### PR DESCRIPTION
The JavaScript lint template in some conditional added some unnecessary spaces that ended up broken the pipeline on GitHub.
Adjusted the python dependencies search to only see a package manager file in the project root path with that, we can avoid a situation where Pipelinit detects a dependency, but when running the pipeline  it can't install it, leaving the pipeline non-functional.

Resolves: https://github.com/pipelinit/pipelinit-cli/issues/88

To test:
- Run the unit tests
- Test in any project with python package managers inside the dependencies and check if the generated files are cohesive. Ex: https://github.com/joao10lima/pipelinit-cli/pull/1

![image](https://user-images.githubusercontent.com/30262244/140312838-eeb6e966-dca0-4ae8-ad4f-3c647cb66173.png)
