### PR TITLE
feat: add java sast stage

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ pipelinit
       <td rowspan="2">CSS</td>
       <td>Format</td>
       <td>✔️</td>
-      <td rowspan="19">Coming soon</td>
+      <td rowspan="20">Coming soon</td>
     </tr>
     <tr>
       <td>Lint</td>
@@ -146,8 +146,12 @@ pipelinit
       <td>✔️</td>
     </tr>
     <tr>
-      <td>Java</td>
-      <td>Build (Gradle)</td>
+      <td rowspan="2">Java</td>
+      <td>Build (Gradle)</td>      
+      <td>✔️</td>
+    </tr>
+    <tr>
+      <td>SAST (Semgrep)</td>
       <td>✔️</td>
     </tr>
     <tr>

--- a/core/templates/github/java/sast.yaml
+++ b/core/templates/github/java/sast.yaml
@@ -1,0 +1,16 @@
+name: SAST
+on:
+  pull_request:
+    paths:
+      - "**.java"
+jobs:
+  semgrep:
+    name: Scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: returntocorp/semgrep-action@v1
+        with:          
+          config: >-   
+            p/java
+            p/security-audit

--- a/tests/fixtures/java/java-build-gradle/expected/.github/workflows/pipelinit.java.sast.yaml
+++ b/tests/fixtures/java/java-build-gradle/expected/.github/workflows/pipelinit.java.sast.yaml
@@ -1,0 +1,18 @@
+# Generated with pipelinit 0.2.2
+# https://pipelinit.com/
+name: SAST
+on:
+  pull_request:
+    paths:
+      - "**.java"
+jobs:
+  semgrep:
+    name: Scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: returntocorp/semgrep-action@v1
+        with:          
+          config: >-   
+            p/java
+            p/security-audit


### PR DESCRIPTION
Add a semgrep SAST (Static application security testing) stage for the Java stack, including the rulesets: "java"  (default ruleset for Java) and "security-audit" (scan code for potential security issues that require additional review).
Add pipelinit.java.sast.yaml file to expected folder.
Add SAST stage to Java stack on the Supported Stacks table in ReadMe File.

Resolves: #76 

To test:
In a GitHub repository with a java project, create a Pull Request of a branch. See the tests performed also in the Action tab.