### PR TITLE
Feat: docker add sast stage

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,19 +88,23 @@ pipelinit
       <td rowspan="2">CSS</td>
       <td>Format</td>
       <td>✔️</td>
-      <td rowspan="20">Coming soon</td>
+      <td rowspan="21">Coming soon</td>
     </tr>
     <tr>
       <td>Lint</td>
       <td>✔️</td>
     </tr>
     <tr>
-      <td rowspan="2">Docker</td>
+      <td rowspan="3">Docker</td>
       <td>Build</td>
       <td>✔️</td>
     </tr>
     <tr>
       <td>Lint</td>
+      <td>✔️</td>
+    </tr>
+    <tr>
+      <td>SAST (Semgrep)</td>
       <td>✔️</td>
     </tr>
     <tr>

--- a/core/templates/github/docker/sast.yaml
+++ b/core/templates/github/docker/sast.yaml
@@ -1,4 +1,4 @@
-name: SAST
+name: SAST Docker
 on:
   pull_request:
     paths:

--- a/core/templates/github/docker/sast.yaml
+++ b/core/templates/github/docker/sast.yaml
@@ -1,0 +1,15 @@
+name: SAST
+on:
+  pull_request:
+    paths:
+      - "**Dockerfile"
+jobs:
+  semgrep:
+    name: Scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: returntocorp/semgrep-action@v1
+        with:          
+          config: >-   
+            p/docker

--- a/tests/fixtures/docker/docker-lint-build/expected/.github/workflows/pipelinit.docker.sast.yaml
+++ b/tests/fixtures/docker/docker-lint-build/expected/.github/workflows/pipelinit.docker.sast.yaml
@@ -1,0 +1,17 @@
+# Generated with pipelinit 0.2.2
+# https://pipelinit.com/
+name: SAST
+on:
+  pull_request:
+    paths:
+      - "**Dockerfile"
+jobs:
+  semgrep:
+    name: Scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: returntocorp/semgrep-action@v1
+        with:          
+          config: >-   
+            p/docker


### PR DESCRIPTION
Add a semgrep SAST (Static application security testing) stage for Docker.

Resolves: #75 

To test:
In a GitHub repository with a Docker file, create a Pull Request of a branch. See the tests performed also in the Action tab.

To test the semgrep generic.dockerfile.security.last-user-is-root.last-user-is-root  rule:
<img width="218" alt="docker-sast-code-with-error" src="https://user-images.githubusercontent.com/23437211/146446625-fb96fd38-28e3-4a61-994f-72510a4c7feb.png">

We get this on GitHub PR:
<img width="670" alt="docker-sast-checks-not-successful" src="https://user-images.githubusercontent.com/23437211/146446725-5a3559c4-095c-4d00-8a64-c3162df9eb03.png">

And this in GitHub Actions:
<img width="916" alt="docker-sast-actions" src="https://user-images.githubusercontent.com/23437211/146446782-3ee00bf9-b9dc-456a-8bf5-024bc131cd97.png">

<img width="457" alt="docker-sast-actions-details" src="https://user-images.githubusercontent.com/23437211/146446868-c6a1ebeb-61af-4a15-898f-ee43ea96e453.png">