### PR TITLE
Style/corrects name sast stage

### DIFF
--- a/core/templates/github/java/sast.yaml
+++ b/core/templates/github/java/sast.yaml
@@ -1,4 +1,4 @@
-name: SAST
+name: SAST Java
 on:
   pull_request:
     paths:

--- a/core/templates/github/javascript/sast.yaml
+++ b/core/templates/github/javascript/sast.yaml
@@ -1,4 +1,4 @@
-name: SAST
+name: SAST JavaScript
 on:
   pull_request:
     paths:

--- a/core/templates/github/python/sast.yaml
+++ b/core/templates/github/python/sast.yaml
@@ -1,4 +1,4 @@
-name: SAST
+name: SAST Python
 on:
   pull_request:
     paths:

--- a/tests/fixtures/docker/docker-lint-build/expected/.github/workflows/pipelinit.javascript.sast.yaml
+++ b/tests/fixtures/docker/docker-lint-build/expected/.github/workflows/pipelinit.javascript.sast.yaml
@@ -1,6 +1,6 @@
 # Generated with pipelinit 0.3.0
 # https://pipelinit.com/
-name: SAST
+name: SAST JavaScript
 on:
   pull_request:
     paths:

--- a/tests/fixtures/java/java-build-gradle/expected/.github/workflows/pipelinit.java.sast.yaml
+++ b/tests/fixtures/java/java-build-gradle/expected/.github/workflows/pipelinit.java.sast.yaml
@@ -1,6 +1,6 @@
 # Generated with pipelinit 0.3.0
 # https://pipelinit.com/
-name: SAST
+name: SAST Java
 on:
   pull_request:
     paths:

--- a/tests/fixtures/javascript/npm-no-deps/expected/.github/workflows/pipelinit.javascript.sast.yaml
+++ b/tests/fixtures/javascript/npm-no-deps/expected/.github/workflows/pipelinit.javascript.sast.yaml
@@ -1,6 +1,6 @@
 # Generated with pipelinit 0.3.0
 # https://pipelinit.com/
-name: SAST
+name: SAST JavaScript
 on:
   pull_request:
     paths:

--- a/tests/fixtures/javascript/vue-html/expected/.github/workflows/pipelinit.javascript.sast.yaml
+++ b/tests/fixtures/javascript/vue-html/expected/.github/workflows/pipelinit.javascript.sast.yaml
@@ -1,6 +1,6 @@
 # Generated with pipelinit 0.3.0
 # https://pipelinit.com/
-name: SAST
+name: SAST JavaScript
 on:
   pull_request:
     paths:

--- a/tests/fixtures/python/python-django/expected/.github/workflows/pipelinit.python.sast.yaml
+++ b/tests/fixtures/python/python-django/expected/.github/workflows/pipelinit.python.sast.yaml
@@ -1,6 +1,6 @@
 # Generated with pipelinit 0.3.0
 # https://pipelinit.com/
-name: SAST
+name: SAST Python
 on:
   pull_request:
     paths:

--- a/tests/fixtures/python/requirements-black-and-pyproject/expected/.github/workflows/pipelinit.python.sast.yaml
+++ b/tests/fixtures/python/requirements-black-and-pyproject/expected/.github/workflows/pipelinit.python.sast.yaml
@@ -1,6 +1,6 @@
 # Generated with pipelinit 0.3.0
 # https://pipelinit.com/
-name: SAST
+name: SAST Python
 on:
   pull_request:
     paths:

--- a/tests/fixtures/python/requirements-unknown-version/expected/.github/workflows/pipelinit.python.sast.yaml
+++ b/tests/fixtures/python/requirements-unknown-version/expected/.github/workflows/pipelinit.python.sast.yaml
@@ -1,6 +1,6 @@
 # Generated with pipelinit 0.3.0
 # https://pipelinit.com/
-name: SAST
+name: SAST Python
 on:
   pull_request:
     paths:

--- a/tests/fixtures/python/setup-flake8/expected/.github/workflows/pipelinit.python.sast.yaml
+++ b/tests/fixtures/python/setup-flake8/expected/.github/workflows/pipelinit.python.sast.yaml
@@ -1,6 +1,6 @@
 # Generated with pipelinit 0.3.0
 # https://pipelinit.com/
-name: SAST
+name: SAST Python
 on:
   pull_request:
     paths:


### PR DESCRIPTION

Adds file type in the name of SAST stage, so when there is more then one file type scanned with semgrep, it is easier to identify which is which on GitHub Actions Tab.

Before:
<img width="213" alt="nome-sast (2)" src="https://user-images.githubusercontent.com/23437211/146773493-aae89e5e-bf6d-452e-abac-2dd6fb8e34df.png">


After:
<img width="209" alt="nome-sast2-1" src="https://user-images.githubusercontent.com/23437211/146773388-a77da188-4c5c-423d-8de4-9ad02da9e1d4.png">

