### PR TITLE
feat: add support for setup.py

### DIFF
--- a/core/plugins/stack/python/version.ts
+++ b/core/plugins/stack/python/version.ts
@@ -40,12 +40,16 @@ file with a version inside, like "3.9".
 See https://github.com/pyenv/pyenv
 `;
 
-/*Search for a setup.py file with python version*/
+/** Search a setup.py file. If the project uses Python, it has a key
+ * with the Python version
+ * As an example:
+ * @see https://docs.python.org/pt-br/3.6/distutils/introduction.html
+ */
 const setup: IntrospectFn<string | Error> = async (context) => {
   for await (const file of context.files.each("**/setup.py")) {
     const setupText = await context.files.readText(file.path);
 
-    const setupVersion: string | null = Array.from(
+    const setupVersion = Array.from(
       setupText.matchAll(/python_requires="(..(?<Version>.*))"/gm),
       (match) => !match.groups ? null : match.groups.Version,
     )[0];
@@ -110,6 +114,7 @@ const poetry: IntrospectFn<string | Error> = async (context) => {
  * - .python-version (from pyenv)
  * - Pipfile (from Pipenv)
  * - pyproject.toml (used by Poetry too)
+ * - setup.py (from Setup)
  *
  * If it fails to find a version definition anywhere, the next step depends
  * wheter Pipelinit is running in the strict mode. It emits an error if running

--- a/tests/default_test.ts
+++ b/tests/default_test.ts
@@ -77,35 +77,7 @@ test(
   { fixture: "python/setup-flake8", args: ["--no-strict"] },
   async (stdout, _stderr, code, assertExpectedFiles) => {
     assertStringIncludes(stdout, "Detected stack: python");
-    assertStringIncludes(
-      stdout,
-      "Couldn't detect the Python version, using the latest available: 3.10",
-    );
-    assertStringIncludes(
-      stdout,
-      "No linters for python were identified in the project, creating default pipeline with 'flake8' WITHOUT any specific configuration",
-    );
-    assertStringIncludes(
-      stdout,
-      "No formatters for python were identified in the project, creating default pipeline with 'black' WITHOUT any specific configuration",
-    );
-    assertStringIncludes(
-      stdout,
-      "No formatters for python were identified in the project, creating default pipeline with 'isort' WITHOUT any specific configuration",
-    );
-    assertEquals(code, 0);
-    await assertExpectedFiles();
-  },
-);
 
-test(
-  { fixture: "python/setup-flake8", args: ["--no-strict"] },
-  async (stdout, _stderr, code, assertExpectedFiles) => {
-    assertStringIncludes(stdout, "Detected stack: python");
-    assertStringIncludes(
-      stdout,
-      "Couldn't detect the Python version, using the latest available: 3.10",
-    );
     assertStringIncludes(
       stdout,
       "No linters for python were identified in the project, creating default pipeline with 'flake8' WITHOUT any specific configuration",

--- a/tests/fixtures/python/setup-flake8/expected/.github/workflows/pipelinit.python.format.yaml
+++ b/tests/fixtures/python/setup-flake8/expected/.github/workflows/pipelinit.python.format.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.10"
+          python-version: "3.8"
 
       - run: python -m pip install pip isort
       - run: python -m pip install pip black

--- a/tests/fixtures/python/setup-flake8/expected/.github/workflows/pipelinit.python.lint.yaml
+++ b/tests/fixtures/python/setup-flake8/expected/.github/workflows/pipelinit.python.lint.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.10"
+          python-version: "3.8"
 
       - run: python -m pip install pip flake8
       - run: python -m pip install pip bandit


### PR DESCRIPTION
Added support for setup.py, for discovering the Python version in the project.

#104 

Tested with the comand **pipelinit** in some Python projects:

- https://github.com/pipelinit/pipelinit-cli
- https://github.com/Madoshakalaka/pipenv-setup
- https://github.com/codrsquad/setupmeta
- https://github.com/aweidner/setupy





![pipelinit python format yaml - setupmeta  WSL_ Ubuntu-20 04  - Visual Studio Code 20_12_2021 15_16_10](https://user-images.githubusercontent.com/81980069/146814255-8f4730bf-86d3-40c7-9664-6ec65a8ddd39.png)

