### PR TITLE
chore: improve Docker image build

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,7 +48,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           build-args: "version=${{ env.RELEASE_VERSION }}"
-          context: cli/
+          file: cli/Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ on your browser! 🚀
 Run the command below inside a checkout of your project's source code:
 
 ```
-docker run -it -v $(pwd):/app ghcr.io/pipelinit/pipelinit-cli
+docker run -it -v $(pwd):/workdir ghcr.io/pipelinit/pipelinit-cli
 ```
 
 ### Using package managers

--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -1,10 +1,19 @@
-FROM debian:11-slim
-
-ARG version
-COPY bin/pipelinit-${version}-x86_64-unknown-linux-gnu /pipelinit
-
-VOLUME ["/app"]
-
+# Based on https://github.com/denoland/deno_docker
+FROM denoland/deno:alpine-1.17.1
 WORKDIR /app
+COPY cli/deps.ts cli/deps.ts
+COPY core/ core/
+RUN deno cache --unstable cli/deps.ts
+COPY cli/ cli/
+RUN deno cache --unstable cli/pipelinit.ts
 
-ENTRYPOINT ["/pipelinit"]
+WORKDIR /workdir
+RUN chown -R deno:deno /workdir
+USER deno
+
+# The ENTRYPOINT is overwritten here to allow passing args to pipelinit itself,
+# otherwsise flags and args would be interpreted by deno.
+# See:
+# https://github.com/denoland/deno_docker/blob/aeb3905/_entry.sh#L4-L7
+ENTRYPOINT ["deno", "run", "--unstable", "--allow-read=.,/app/core/templates", "--allow-write=.", "/app/cli/pipelinit.ts"]
+CMD [""]

--- a/cli/README.md
+++ b/cli/README.md
@@ -49,3 +49,15 @@ It also generates one executable named just "pipelinit", that uses the native
 target (the computer where you ran the build).
 
 The build script puts those files in the "bin" directory.
+
+### Docker
+
+To build the Docker image, run the following command in the project root:
+```
+docker build -t pipelinit -f cli/Dockerfile .
+```
+
+This build a local image tagged as `pipelinit:latest` that you can use with:
+```
+docker run -it -v $(pwd):/workdir pipelinit:latest
+```


### PR DESCRIPTION
Updates the Dockerfile definition to build the Pipelinit CLI Docker image without depending on a previous manual build step or any external artifacts besides the docker executable and the versioned source code.

That is, now the Docker build is independent and can run in an isolated CI job. This is required to make sure Pipelinit can generate pipelines to build itself.

The new image is slightly smaller too:
```
❯ docker image ls | grep pipelinit
pipelinit                                   latest         e7506bec06c9   7 seconds ago   114MB
ghcr.io/pipelinit/pipelinit-cli             latest         9215bc027a00   11 days ago     168MB
```

It's possible to shrink it further to 107MB, but at the cost of some complexity in the Dockerfile and build process:

<details>
<summary>Click to check the alternative Dockerfile</summary>

```Dockerfile
FROM denoland/deno:alpine-1.17.1 AS builder
ARG RELEASE_VERSION
ENV RELEASE_VERSION=${RELEASE_VERSION}
ENV BUILD_TARGET="x86_64-unknown-linux-gnu"
WORKDIR /app
COPY core/ core/
COPY cli/ cli/
RUN cd cli && deno run --unstable --allow-read --allow-write --allow-net --allow-env --allow-run build.ts


FROM frolvlad/alpine-glibc:alpine-3.13
ARG RELEASE_VERSION

RUN addgroup --gid 1000 pipelinit \
  && adduser --uid 1000 --disabled-password pipelinit --ingroup pipelinit

WORKDIR /workdir
RUN chown -R pipelinit:pipelinit /workdir

COPY --from=builder /app/cli/bin/pipelinit-${RELEASE_VERSION}-x86_64-unknown-linux-gnu /bin/pipelinit

USER pipelinit
ENTRYPOINT ["/bin/pipelinit"]
```

Now the RELEASE_VERSION build argument is required:
```
docker build --build-arg RELEASE_VERSION=0.3.0 -t pipelinit -f cli/Dockerfile .
```

</details>

I don't think it's worth it.


closes #57