### PR TITLE
fix: removed redundant info and changed standard messages

### DIFF
--- a/core/plugins/stack/css/linters.ts
+++ b/core/plugins/stack/css/linters.ts
@@ -28,7 +28,7 @@ export const introspect: IntrospectFn<Linters> = async (context) => {
   if (anyValue(linters)) return linters;
 
   if (context.suggestDefault) {
-    logger.warning("No CSS linter detected, using stylelint");
+    logger.warning("No CSS linter detected, using Stylelint");
     return {
       stylelint: { name: "stylelint" },
     };

--- a/core/plugins/stack/markdown/mod.ts
+++ b/core/plugins/stack/markdown/mod.ts
@@ -8,9 +8,8 @@ export const introspector: Introspector<MarkdownProject> = {
     return await context.files.includes("**/*.md");
   },
   introspect: async (context) => {
+    // deno-lint-ignore no-unused-vars
     const logger = await context.getLogger("markdown");
-    logger.info("Detected Markdown File");
-
     return {};
   },
 };

--- a/core/plugins/stack/python/formatters.ts
+++ b/core/plugins/stack/python/formatters.ts
@@ -20,7 +20,7 @@ export const introspect: IntrospectFn<Formatters> = async (context) => {
   } else {
     if (context.suggestDefault) {
       logger.warning(
-        "No formatters for python were identified in the project, creating default pipeline with 'black' WITHOUT any specific configuration",
+        "No Python formatter detected, using Black",
       );
       formatters.black = {
         isDependency: false,
@@ -35,7 +35,7 @@ export const introspect: IntrospectFn<Formatters> = async (context) => {
   } else {
     if (context.suggestDefault) {
       logger.warning(
-        "No formatters for python were identified in the project, creating default pipeline with 'isort' WITHOUT any specific configuration",
+        "No Python linter detected, using isort",
       );
       formatters.isort = {
         isDependency: false,

--- a/core/plugins/stack/python/linters.ts
+++ b/core/plugins/stack/python/linters.ts
@@ -23,7 +23,7 @@ export const introspect: IntrospectFn<Linters> = async (context) => {
   } else {
     if (context.suggestDefault) {
       logger.warning(
-        "No linters for python were identified in the project, creating default pipeline with 'flake8' WITHOUT any specific configuration",
+        "No Python linter detected, using Flake8",
       );
       linters.flake8 = {
         isDependency: false,
@@ -43,7 +43,7 @@ export const introspect: IntrospectFn<Linters> = async (context) => {
   } else {
     if (context.suggestDefault) {
       logger.warning(
-        "No linters for python were indentified in the project, creating default with 'bandit' WITHOUT any specific configuration",
+        "No Python linter detected, using Bandit",
       );
       linters.bandit = {
         isDependency: false,

--- a/core/plugins/stack/ruby/formatters.ts
+++ b/core/plugins/stack/ruby/formatters.ts
@@ -17,7 +17,7 @@ export const introspect: IntrospectFn<Formatters> = async (context) => {
   } else {
     if (context.suggestDefault) {
       logger.warning(
-        "No formatters for ruby were identified in the project, creating default pipeline with 'Rubocop' WITHOUT any specific configuration",
+        "No Ruby formatter detected, using Rubocop",
       );
       formatters.rubocop = {
         isDependency: false,

--- a/core/plugins/stack/ruby/linters.ts
+++ b/core/plugins/stack/ruby/linters.ts
@@ -16,7 +16,7 @@ export const introspect: IntrospectFn<Linters> = async (context) => {
   } else {
     if (context.suggestDefault) {
       logger.warning(
-        "No linters for ruby were identified in the project, creating default pipeline with 'Rubocop' WITHOUT any specific configuration",
+        "No Ruby linter detected, using Rubocop",
       );
       linters.rubocop = {
         isDependency: false,

--- a/core/plugins/stack/ruby/mod.ts
+++ b/core/plugins/stack/ruby/mod.ts
@@ -32,7 +32,6 @@ export const introspector: Introspector<RubyProject | undefined> = {
   },
   introspect: async (context) => {
     const logger = context.getLogger("ruby");
-    logger.info("Detected Ruby File");
 
     // Version
     logger.debug("detecting version");

--- a/tests/default_test.ts
+++ b/tests/default_test.ts
@@ -45,11 +45,11 @@ test(
     );
     assertStringIncludes(
       stdout,
-      "No linters for python were identified in the project, creating default pipeline with 'flake8' WITHOUT any specific configuration",
+      "No Python linter detected, using Flake8",
     );
     assertStringIncludes(
       stdout,
-      "No formatters for python were identified in the project, creating default pipeline with 'black' WITHOUT any specific configuration",
+      "No Python formatter detected, using Black",
     );
     assertEquals(code, 0);
     await assertExpectedFiles();
@@ -62,11 +62,11 @@ test(
     assertStringIncludes(stdout, "Detected stack: python");
     assertStringIncludes(
       stdout,
-      "No linters for python were identified in the project, creating default pipeline with 'flake8' WITHOUT any specific configuration",
+      "No Python linter detected, using Flake8",
     );
     assertStringIncludes(
       stdout,
-      "No formatters for python were identified in the project, creating default pipeline with 'isort' WITHOUT any specific configuration",
+      "No Python linter detected, using isort",
     );
     assertEquals(code, 0);
     await assertExpectedFiles();
@@ -80,15 +80,15 @@ test(
 
     assertStringIncludes(
       stdout,
-      "No linters for python were identified in the project, creating default pipeline with 'flake8' WITHOUT any specific configuration",
+      "No Python linter detected, using Flake8",
     );
     assertStringIncludes(
       stdout,
-      "No formatters for python were identified in the project, creating default pipeline with 'black' WITHOUT any specific configuration",
+      "No Python formatter detected, using Black",
     );
     assertStringIncludes(
       stdout,
-      "No formatters for python were identified in the project, creating default pipeline with 'isort' WITHOUT any specific configuration",
+      "No Python linter detected, using isort",
     );
     assertEquals(code, 0);
     await assertExpectedFiles();
@@ -154,7 +154,7 @@ test(
     assertStringIncludes(stdout, "Detected stack: markdown, python, shell");
     assertStringIncludes(
       stdout,
-      "No formatters for python were identified in the project, creating default pipeline with 'black' WITHOUT any specific configuration",
+      "No Python formatter detected, using Black",
     );
     assertEquals(code, 0);
     await assertExpectedFiles();
@@ -184,7 +184,7 @@ test(
     assertStringIncludes(stdout, "Detected stack: python");
     assertStringIncludes(
       stdout,
-      "No formatters for python were identified in the project, creating default pipeline with 'black' WITHOUT any specific configuration",
+      "No Python formatter detected, using Black",
     );
     assertEquals(code, 0);
     await assertExpectedFiles();


### PR DESCRIPTION

- Fix redundant messages ("Detected File") in CLI. 

- Standardize warning messages like -> "No (stack) (tool type) detected, using (tool)"

>![messages](https://user-images.githubusercontent.com/31106626/148255705-196f1c82-7192-4182-9e4f-c90d6410abbb.PNG)

- Fix incorrect names