### PR TITLE
fix: install instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ Pipelinit is built with Deno check how to install it
 [on the official Deno website](https://deno.land/#installation).
 To install the executable locally, use the command:
 
-```deno install -f --unstable --allow-read=.,$(pwd) --allow-write=. cli/pipelinit.ts```
+```deno install -A -f --unstable cli/pipelinit.ts```
 
 This automatically updates the executable as you change the source code,
 eliminating the need to rebuild and reinstall the CLI.

--- a/README.md
+++ b/README.md
@@ -29,14 +29,6 @@ on your browser! 🚀
 
 ## How to install
 
-### Using a Docker image
-
-Run the command below inside a checkout of your project's source code:
-
-```
-docker run -it -v $(pwd):/workdir ghcr.io/pipelinit/pipelinit-cli
-```
-
 ### Using package managers
 
 Homebrew (macOS):
@@ -53,6 +45,25 @@ yay -Sy pipelinit-bin
 ```
 
 Support for more package managers needed!
+
+### Install version with latest changes
+
+Start by installing [Deno](https://deno.land/) following their [official site](https://deno.land/#installation)
+
+Checkout the Pipelinit repository in your computer:
+```
+git clone https://github.com/pipelinit/pipelinit-cli.git
+```
+
+Then install Pipelinit with the Deno script installer:
+```
+deno install -A -f --unstable cli/pipelinit.ts
+```
+
+You should see the following message in your terminal:
+```
+✅ Successfully installed pipelinit
+```
 
 ### Manual download
 

--- a/cli/install.sh
+++ b/cli/install.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+echo "Downloading latest Pipelinit binary" &&
+  curl -s https://api.github.com/repos/pipelinit/pipelinit-cli/releases/latest | grep -E 'browser_download_url.*linux*' | cut -d '"' -f 4 | wget -qi - &&
+  echo "Download completed! Unpacking the file" &&
+  tar -xf pipelinit-v*.tar.gz && rm pipelinit-v*.tar.gz &&
+  echo "Moving the file to the default PATH: $HOME/.local/bin/" &&
+  mv pipelinit-v* "$HOME/.local/bin/pipelinit" &&
+  echo -e "\e[1;32mInstalled with success! If you have $HOME/.local/bin/ in your PATH run with 'pipelinit' case not run with the full path '$HOME/.local/bin/pipelinit'"

--- a/cli/src/lib/context/files.ts
+++ b/cli/src/lib/context/files.ts
@@ -24,6 +24,10 @@ async function loadGitignoreExcludes() {
       }
       excludedFiles.push(file);
     }
+    // Specifically ignore 'node_modules'
+    excludedFiles.push("**/node_modules/**");
+    // Ignore hidden directories
+    excludedFiles.push("**/.*/**");
     return excludedFiles;
   }
   return [];

--- a/docs/howto/write-a-new-plugin.md
+++ b/docs/howto/write-a-new-plugin.md
@@ -240,7 +240,7 @@ import { introspect as introspectDjango } from "./django.ts";
 ##### Run a local build of the Pipelinit CLI in the root of your project
 Run the command:
 
-```deno install -f --unstable --allow-read=.,$(pwd) --allow-write=. cli/pipelinit.ts```
+```deno install -A -f --unstable cli/pipelinit.ts```
 
 ##### Push the project and test the generated workflow.
 

--- a/docs/tutorials/creating-a-plugin-for-markdown.md
+++ b/docs/tutorials/creating-a-plugin-for-markdown.md
@@ -12,7 +12,7 @@ it [on the official Deno website](https://deno.land/#installation).
 Checkout the Pipelinit repository in your computer and install Pipelinit with
 Deno script installer:
 ```
-deno install -f --unstable --allow-read=.,$(pwd) --allow-write=. cli/pipelinit.ts
+deno install -A -f --unstable cli/pipelinit.ts
 ```
 
 You should see the following message in your terminal:

--- a/tests/fixtures/javascript/multiples-packages/expected/.github/workflows/pipelinit.javascript.format.yaml
+++ b/tests/fixtures/javascript/multiples-packages/expected/.github/workflows/pipelinit.javascript.format.yaml
@@ -1,0 +1,20 @@
+# Generated with pipelinit 0.4.0
+# https://pipelinit.com/
+name: Format JavaScript
+on:
+  pull_request:
+    paths:
+      - '**.js'
+      - '**.ts'
+jobs:
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+          cache: 'yarn'
+      - run: yarn
+      - run: npx prettier --no-error-on-unmatched-pattern --check "**/*.js" "**/*.ts"
+      

--- a/tests/fixtures/javascript/multiples-packages/expected/.github/workflows/pipelinit.javascript.lint.yaml
+++ b/tests/fixtures/javascript/multiples-packages/expected/.github/workflows/pipelinit.javascript.lint.yaml
@@ -1,0 +1,31 @@
+# Generated with pipelinit 0.4.0
+# https://pipelinit.com/
+name: Lint JavaScript
+on:
+  pull_request:
+    paths:
+      - '**.js'
+      - '**.ts'
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+          cache: 'yarn'
+      - run: yarn
+      - run: npx eslint --ext .js --ext .ts .
+      
+  tsc:
+    name: Typecheck Typescript
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+          cache: 'yarn'
+      - run: yarn
+      - run: NPM_CONFIG_YES=true npx -p typescript -c 'tsc --init && tsc --noEmit'

--- a/tests/fixtures/javascript/multiples-packages/expected/.github/workflows/pipelinit.javascript.sast.yaml
+++ b/tests/fixtures/javascript/multiples-packages/expected/.github/workflows/pipelinit.javascript.sast.yaml
@@ -1,0 +1,18 @@
+# Generated with pipelinit 0.4.0
+# https://pipelinit.com/
+name: SAST JavaScript
+on:
+  pull_request:
+    paths:
+      - '**.js'
+      - '**.ts'
+jobs:
+  semgrep:
+    name: Scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: returntocorp/semgrep-action@v1
+        with:
+          config: >-
+            p/ci

--- a/tests/fixtures/javascript/multiples-packages/project/.gitignore
+++ b/tests/fixtures/javascript/multiples-packages/project/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/tests/fixtures/javascript/multiples-packages/project/.pipelinit.toml
+++ b/tests/fixtures/javascript/multiples-packages/project/.pipelinit.toml
@@ -1,0 +1,1 @@
+platforms = ["github"]

--- a/tests/fixtures/javascript/multiples-packages/project/package.json
+++ b/tests/fixtures/javascript/multiples-packages/project/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "hrcrm",
+  "private": true,
+  "version": "0.1.0",
+  "workspaces": [
+    "web/",
+    "worker/",
+    "apps/*"
+  ],
+  "scripts": {
+    "dev": "SCRIPTY_PARALLEL=true scripty"
+  },
+  "devDependencies": {
+    "scripty": "^2.0.0",
+    "prettier": "^2.1.2",
+    "eslint": "^7.10.0",
+    "eslint-config-prettier": "^7.1.0",
+    "eslint-plugin-prettier": "^3.1.4"
+  },
+  "engines": {
+    "node": "16.13"
+  }
+}

--- a/tests/fixtures/javascript/multiples-packages/project/worker.ts
+++ b/tests/fixtures/javascript/multiples-packages/project/worker.ts
@@ -1,0 +1,5 @@
+const bullMq = async () => {
+  await console.log("Worker started");
+};
+
+bullMq();

--- a/tests/stacks/javascript_test.ts
+++ b/tests/stacks/javascript_test.ts
@@ -31,3 +31,12 @@ test(
     await assertExpectedFiles();
   },
 );
+
+test(
+  { fixture: "javascript/multiples-packages", args: [] },
+  async (stdout, _stderr, code, assertExpectedFiles) => {
+    assertStringIncludes(stdout, "Detected stack: javascript");
+    assertEquals(code, 0);
+    await assertExpectedFiles();
+  },
+);


### PR DESCRIPTION
By default when Pipelinit introspects a repository
It uses the repo `.gitignore` to exclude unnecessary/static files
which slowdown the cli run, this works for most of the scenarios
however, in some cases when the introspected repo has multiples
`node_modules` this may not happen.

This commit adds a manual rule in the globExclude option
to filter ANY `node_modules` directory and any `hidden directory`.

NOTE: Only hidden directories are affected. Pipelinit MUST
check some hidden files in is introspection like `.nvmrc` and
`.eslintrc`.