### PR TITLE
docs: add js stack to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ pipelinit
       <td rowspan="2">CSS</td>
       <td>Format</td>
       <td>✔️</td>
-      <td rowspan="14">Coming soon</td>
+      <td rowspan="9">Coming soon</td>
     </tr>
     <tr>
       <td>Lint</td>
@@ -148,23 +148,28 @@ pipelinit
       <td rowspan="4">JavaScript / TypeScript</td>
       <td>Format</td>
       <td>✔️</td>
+      <td>✔️</td>
     </tr>
     <tr>
       <td>Lint</td>
+      <td>✔️</td>
       <td>✔️</td>
     </tr>
     <tr>
       <td>Test</td>
       <td>✔️</td>
+      <td>✔️</td>
     </tr>
     <tr>
       <td>SAST</td>
+      <td>✔️</td>
       <td>✔️</td>
     </tr>
     <tr>
       <td rowspan="1">Markdown</td>
       <td>Lint</td>
       <td>✔️</td>
+      <td>Coming soon</td>
     </tr>
     <tr>
       <td rowspan="4">Python</td>


### PR DESCRIPTION
Updated Github javascript support in the stacks table.

- ![image](https://user-images.githubusercontent.com/31106626/158256447-454d3a1c-0cc2-4576-97fb-577878e0180a.png)
